### PR TITLE
chore: refit terminal after initial loading to correct size

### DIFF
--- a/packages/frontend/src/lib/disk-image/DiskImageDetailsBuild.svelte
+++ b/packages/frontend/src/lib/disk-image/DiskImageDetailsBuild.svelte
@@ -24,6 +24,16 @@ let termFit: FitAddon;
 let logsTerminal: Terminal;
 let logInterval: NodeJS.Timeout;
 
+// This is an issue with xterm not resizing properly when first initializing / loading
+// the terminal due to how we add padding. We must therefore call fit() approx 10ms after
+// initial loading to make sure the terminal is properly sized.
+// this is only called once when switching from no logs to logs
+$: if (noLogs === false) {
+  setTimeout(() => {
+    termFit?.fit();
+  }, 10);
+}
+
 async function fetchFolderLogs() {
   if (!folder) {
     return;

--- a/packages/frontend/src/lib/disk-image/DiskImageDetailsVirtualMachine.svelte
+++ b/packages/frontend/src/lib/disk-image/DiskImageDetailsVirtualMachine.svelte
@@ -35,6 +35,16 @@ let notifySubscriber: Subscriber;
 const VM_LAUNCH_ERROR_MESSAGE = 'VM launch error';
 const GUIDE_LINK = 'https://github.com/containers/podman-desktop-extension-bootc/blob/main/docs/vm_launcher.md';
 
+// This is an issue with xterm not resizing properly when first initializing / loading
+// the terminal due to how we add padding. We must therefore call fit() approx 10ms after
+// initial loading to make sure the terminal is properly sized.
+// this is only called once when switching from no logs to logs
+$: if (noLogs === false) {
+  setTimeout(() => {
+    termFit?.fit();
+  }, 10);
+}
+
 // Event handlers for the WebSocket connection
 // which are needed to update the connection status
 function closeHandler(event: CloseEvent) {
@@ -308,7 +318,7 @@ export function goToHomePage(): void {
   <DiskImageConnectionStatus status={connectionStatus} />
 </div>
 <div
-  class="min-w-full flex flex-col p-[5px] pb-[10px] pr-0 bg-[var(--pd-terminal-background)]"
+  class="min-w-full flex flex-col p-[5px] pr-0 bg-[var(--pd-terminal-background)]"
   class:invisible={noLogs}
   class:h-0={noLogs}
   class:h-full={!noLogs}


### PR DESCRIPTION
chore: refit terminal after initial loading to correct size

### What does this PR do?

`xterm.js` has an odd issue where it will not resize the terminal on
initial loading.

After a long time troubleshooting, there is no ideal fix as we are
loading the terminal within many other divs and it's unable to properly
refit itself.

This is causing issues with the scroll-bar being inaccurate. Even after
adding proper CSS / tailwind values for spacing, it is inaccurate / not
correct.

This adds a reactive statement that refits the terminal after a very
short 10ms delay after logs appear.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/podman-desktop/podman-desktop-extension-bootc/issues/997

### How to test this PR?

<!-- Please explain steps to reproduce -->

1. Load logs
2. No longer see padding on the bottom

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
