### PR TITLE
chore: rename section

### DIFF
--- a/packages/backend/assets/examples.json
+++ b/packages/backend/assets/examples.json
@@ -41,7 +41,7 @@
   "categories": [
     {
       "id": "fedora",
-      "name": "Fedora BootC Images"
+      "name": "Fedora Bootable Container Images"
     }
   ]
 }


### PR DESCRIPTION
chore: rename section

### What does this PR do?

Renames the section instead of saying BootC, use the proper named
Bootable Container.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

N/A

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

N/A

### How to test this PR?

<!-- Please explain steps to reproduce -->

N/A

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
