### PR TITLE
feat: add build config configurator

### DIFF
--- a/packages/backend/src/build-disk-image.spec.ts
+++ b/packages/backend/src/build-disk-image.spec.ts
@@ -477,7 +477,7 @@ test('test createBuildConfigJSON function works when passing in a build config w
     user: [
       {
         name: 'test-user',
-        // eslint-disable-next-line sonarjs/no-hardcoded-credentials
+        // eslint-disable-next-line sonarjs/no-hardcoded-passwords
         password: 'test-password',
         key: 'test-key',
         groups: ['test-group'],
@@ -514,7 +514,7 @@ test('test building with a buildConfig JSON file that a temporary file for build
     user: [
       {
         name: 'test-user',
-        // eslint-disable-next-line sonarjs/no-hardcoded-credentials
+        // eslint-disable-next-line sonarjs/no-hardcoded-passwords
         password: 'test-password',
         key: 'test-key',
         groups: ['test-group'],

--- a/packages/backend/src/build-disk-image.ts
+++ b/packages/backend/src/build-disk-image.ts
@@ -471,12 +471,10 @@ export function createBuilderImageOptions(
 
     // Make sure that cutomizations is exists and is not empty before adding it to the container.
     if (buildConfig.customizations && Object.keys(buildConfig.customizations).length > 0) {
-      // Create a temporary path to store the buildConfig JSON
-      // with a temporary name
-      // eslint-disable-next-line sonarjs/pseudo-random
-      const buildConfigPath = path.join(os.tmpdir(), `${Math.floor(Math.random() * 100000)}.json`);
+      // Use the folder of the build to store the buildConfig JSON file as config.json
+      const buildConfigPath = path.join(build.folder, 'config.json');
 
-      // Write the buildConfig JSON to the temporary file with JSON
+      // Write the buildConfig JSON to the file we'll be using
       fs.writeFileSync(buildConfigPath, JSON.stringify(buildConfig, undefined, 2));
 
       // Add the mount to the configuration file

--- a/packages/frontend/src/Build.svelte
+++ b/packages/frontend/src/Build.svelte
@@ -81,6 +81,11 @@ function toggleBuildConfig() {
   showBuildConfig = !showBuildConfig;
 }
 
+let showBuildConfigFile = false;
+function toggleBuildConfigFile() {
+  showBuildConfigFile = !showBuildConfigFile;
+}
+
 function findImage(repoTag: string): ImageInfo | undefined {
   return bootcAvailableImages.find(
     image => image.RepoTags && image.RepoTags.length > 0 && image.RepoTags[0] === repoTag,
@@ -764,14 +769,15 @@ $: if (availableArchitectures) {
                 class="font-semibold mb-2 block cursor-pointer"
                 aria-label="build-config-options"
                 on:click={toggleBuildConfig}
-                ><Fa icon={showBuildConfig ? faCaretDown : faCaretRight} class="inline-block mr-1" />Build config
+                ><Fa icon={showBuildConfig ? faCaretDown : faCaretRight} class="inline-block mr-1" />Interactive build
+                config
               </span>
               {#if showBuildConfig}
                 <p class="text-sm text-[var(--pd-content-text)] mb-2">
                   Supplying the following fields will create a build config file that contains the build options for the
-                  disk image. Customizations include user, password, SSH keys and kickstart files. More information can
-                  be found in the <Link
-                    externalRef="https://github.com/osbuild/bootc-image-builder?tab=readme-ov-file#-build-config"
+                  disk image. This will be saved in the <b>same directory as your output folder</b>. More information
+                  can be found in the <Link
+                    externalRef="https://github.com/osbuild/bootc-image-builder?tab=readme-ov-file\#-build-config"
                     >bootc-image-builder documentation</Link
                   >.
                 </p>
@@ -838,7 +844,7 @@ $: if (availableArchitectures) {
                     <Input
                       bind:value={filesystem.minsize}
                       id="buildConfigFilesystemMinimumSize.${index}"
-                      placeholder="Minimum size (ex. 30 GiB)" />
+                      placeholder="Minimum size (ex. '30 GiB')" />
 
                     <Button
                       type="link"
@@ -864,12 +870,30 @@ $: if (availableArchitectures) {
                   id="buildConfigKernelArguments"
                   placeholder="Kernel arguments (ex. quiet)"
                   class="w-full" />
-
+              {/if}
+            </div>
+            <div class="mb-2">
+              <!-- Use a span for this until we have a "dropdown toggle" UI element implemented. -->
+              <!-- svelte-ignore a11y-click-events-have-key-events -->
+              <!-- svelte-ignore a11y-no-static-element-interactions -->
+              <span
+                class="font-semibold mb-2 block cursor-pointer"
+                aria-label="build-config-options"
+                on:click={toggleBuildConfigFile}
+                ><Fa icon={showBuildConfigFile ? faCaretDown : faCaretRight} class="inline-block mr-1" />Build config
+                file
+              </span>
+              {#if showBuildConfigFile}
+                <p class="text-sm text-[var(--pd-content-text)] mb-2">
+                  Supplying a file will override <b>ANY</b> changes done in the build config interactive mode. More
+                  information can be found in the <Link
+                    externalRef="https://github.com/osbuild/bootc-image-builder?tab=readme-ov-file\#-build-config"
+                    >bootc-image-builder documentation</Link
+                  >.
+                </p>
                 <div>
-                  <span class="block mt-6">File</span>
+                  <span class="block mt-4">File</span>
                 </div>
-
-                <!-- Build config -->
                 <div class="mb-2">
                   <div class="flex flex-row space-x-3">
                     <Input
@@ -881,9 +905,6 @@ $: if (availableArchitectures) {
                       aria-label="buildconfig-select" />
                     <Button on:click={() => getBuildConfigFile()}>Browse...</Button>
                   </div>
-                  <p class="text-sm text-[var(--pd-content-text)] pt-2">
-                    This will override any above user-specific input and use the supplied file only.
-                  </p>
                 </div>
               {/if}
             </div>

--- a/packages/shared/src/models/bootc.ts
+++ b/packages/shared/src/models/bootc.ts
@@ -18,6 +18,35 @@
 
 export type BuildType = 'qcow2' | 'ami' | 'raw' | 'vmdk' | 'anaconda-iso' | 'vhd';
 
+// Follows https://github.com/osbuild/bootc-image-builder?tab=readme-ov-file#-build-config convention
+// users = array
+// filesystems = array
+// kernel = mapping
+export interface BuildConfig {
+  user?: BuildConfigUser[];
+  filesystem?: BuildConfigFilesystem[];
+  kernel?: BuildConfigKernel;
+  // In the future:
+  // * Add installer.kickstart https://github.com/osbuild/bootc-image-builder?tab=readme-ov-file#anaconda-iso-installer-options-installer-mapping
+  // * Add anaconda iso modules https://github.com/osbuild/bootc-image-builder?tab=readme-ov-file#anaconda-iso-installer-modules
+}
+
+export interface BuildConfigUser {
+  name: string;
+  password?: string;
+  key?: string;
+  groups?: string[];
+}
+
+export interface BuildConfigFilesystem {
+  mountpoint: string;
+  minsize: string;
+}
+
+export interface BuildConfigKernel {
+  append: string;
+}
+
 export interface BootcBuildInfo {
   id: string;
   image: string;
@@ -27,6 +56,7 @@ export interface BootcBuildInfo {
   type: BuildType[];
   folder: string;
   chown?: string;
+  buildConfig?: BuildConfig;
   buildConfigFilePath?: string;
   filesystem?: string;
   arch?: string;


### PR DESCRIPTION
feat: add build config configurator

### What does this PR do?

* Adds automated way to create a build config json file
* Added to build page

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->
![Screenshot 2024-11-18 at 3 44 47 PM](https://github.com/user-attachments/assets/a48fdd62-f3aa-4a31-b088-a637632c5fea)


https://github.com/user-attachments/assets/bbf18809-620f-46f5-ad5e-a02c8df69fd0



### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/podman-desktop/extension-bootc/issues/827

### How to test this PR?

<!-- Please explain steps to reproduce -->

Use build config and configure / create your own custom build config
   with users, filesystem, etc.
