### PR TITLE
chore: remove hvf acceleration from amd64 vm command

### DIFF
--- a/packages/backend/src/vm-manager.ts
+++ b/packages/backend/src/vm-manager.ts
@@ -157,8 +157,6 @@ class MacArmX86VMManager extends VMManagerBase {
       'qemu64',
       '-machine',
       'q35',
-      '-accel',
-      'hvf',
       '-smp',
       '4',
       '-serial',


### PR DESCRIPTION
chore: remove hvf acceleration from amd64 vm command

### What does this PR do?

Should not have been added / was added when refactoring. `hvf` should
not be there for amd64 as it's cross-arch and not compatible (hvf only
working for arm).

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

N/A

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Fixes https://github.com/podman-desktop/extension-bootc/issues/1088

### How to test this PR?

<!-- Please explain steps to reproduce -->

1. Create an amd64 image
2. Run VM tab
3. Works / runs.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
