### PR TITLE
fix: e2e main test node setup is failing because of missing pnpm

### DIFF
--- a/.github/workflows/e2e-main.yaml
+++ b/.github/workflows/e2e-main.yaml
@@ -63,6 +63,12 @@ jobs:
           ref: main
           path: podman-desktop
 
+      - uses: pnpm/action-setup@v4
+        name: Install pnpm
+        with:
+          run_install: false
+          package_json_file: ./podman-desktop/package.json
+
       - uses: actions/setup-node@v4
         with:
           node-version: 20
@@ -90,12 +96,6 @@ jobs:
         run: |
           # allow unprivileged user namespace
           sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
-
-      - uses: pnpm/action-setup@v4
-        name: Install pnpm
-        with:
-          run_install: false
-          package_json_file: ./podman-desktop/package.json
 
       - name: Execute pnpm
         working-directory: ./podman-desktop


### PR DESCRIPTION
### What does this PR do?

This pr is moving pnpm install step before node setup step.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include 
screenshots or screencasts showing the difference -->

![image](https://github.com/user-attachments/assets/7ce3db4a-41dd-41cb-86b5-f3a9bc1e2eb5)

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop 
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to reproduce -->
