### PR TITLE
chore: add telemetry for examples

### DIFF
--- a/packages/frontend/src/lib/ExampleCard.spec.ts
+++ b/packages/frontend/src/lib/ExampleCard.spec.ts
@@ -30,6 +30,7 @@ vi.mock('../api/client', () => {
     bootcClient: {
       pullImage: vi.fn(),
       openLink: vi.fn(),
+      telemetryLogUsage: vi.fn(),
     },
   };
 });
@@ -90,10 +91,16 @@ test('pullImage function is called when Pull image button is clicked', async () 
 
   // Find and click the "Pull image" button
   const pullButton = screen.getByTitle('Pull image');
+
+  // spy on telemetryLogUsage function
+  const spyOnLogUsage = vi.spyOn(bootcClient, 'telemetryLogUsage');
+
   await fireEvent.click(pullButton);
 
   // Ensure bootcClient.pullImage is called with the correct image name
   expect(bootcClient.pullImage).toHaveBeenCalledWith('quay.io/example/example1');
+
+  expect(spyOnLogUsage).toHaveBeenCalled();
 });
 
 test('Build image button is displayed if example is pulled', async () => {
@@ -107,9 +114,14 @@ test('Build image button is displayed if example is pulled', async () => {
   const buildButton = screen.getByTitle('Build image');
   expect(buildButton).toBeInTheDocument();
 
+  // spy on telemetryLogUsage function
+  const spyOnLogUsage = vi.spyOn(bootcClient, 'telemetryLogUsage');
+
   // Click the "Build image" button
   await fireEvent.click(buildButton);
 
   // Ensure the router.goto is called with the correct path
   expect(router.goto).toHaveBeenCalledWith('/disk-images/build/quay.io%2Fexample%2Fexample1/latest');
+
+  expect(spyOnLogUsage).toHaveBeenCalled();
 });

--- a/packages/frontend/src/lib/ExampleCard.spec.ts
+++ b/packages/frontend/src/lib/ExampleCard.spec.ts
@@ -92,15 +92,12 @@ test('pullImage function is called when Pull image button is clicked', async () 
   // Find and click the "Pull image" button
   const pullButton = screen.getByTitle('Pull image');
 
-  // spy on telemetryLogUsage function
-  const spyOnLogUsage = vi.spyOn(bootcClient, 'telemetryLogUsage');
-
   await fireEvent.click(pullButton);
 
   // Ensure bootcClient.pullImage is called with the correct image name
   expect(bootcClient.pullImage).toHaveBeenCalledWith('quay.io/example/example1');
 
-  expect(spyOnLogUsage).toHaveBeenCalled();
+  expect(bootcClient.telemetryLogUsage).toHaveBeenCalled();
 });
 
 test('Build image button is displayed if example is pulled', async () => {
@@ -114,14 +111,11 @@ test('Build image button is displayed if example is pulled', async () => {
   const buildButton = screen.getByTitle('Build image');
   expect(buildButton).toBeInTheDocument();
 
-  // spy on telemetryLogUsage function
-  const spyOnLogUsage = vi.spyOn(bootcClient, 'telemetryLogUsage');
-
   // Click the "Build image" button
   await fireEvent.click(buildButton);
 
   // Ensure the router.goto is called with the correct path
   expect(router.goto).toHaveBeenCalledWith('/disk-images/build/quay.io%2Fexample%2Fexample1/latest');
 
-  expect(spyOnLogUsage).toHaveBeenCalled();
+  expect(bootcClient.telemetryLogUsage).toHaveBeenCalled();
 });

--- a/packages/frontend/src/lib/ExampleCard.svelte
+++ b/packages/frontend/src/lib/ExampleCard.svelte
@@ -22,12 +22,14 @@ async function openURL(): Promise<void> {
 async function pullImage(): Promise<void> {
   if (example.image) {
     pullInProgress = true;
+    bootcClient.telemetryLogUsage('example-pull-image', { image: example.image });
     bootcClient.pullImage(example.image);
   }
 }
 
 async function gotoBuild(): Promise<void> {
   if (example.image && example.tag) {
+    bootcClient.telemetryLogUsage('example-build-image', { image: example.image });
     router.goto(`/disk-images/build/${encodeURIComponent(example.image)}/${encodeURIComponent(example.tag)}`);
   }
 }


### PR DESCRIPTION
chore: add telemetry for examples

### What does this PR do?

Adds telemetry for building as well as pulling examples

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

N/A

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/podman-desktop/extension-bootc/issues/1047

### How to test this PR?

<!-- Please explain steps to reproduce -->

Functions on example should work as normal.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
