### PR TITLE
feat: add linux VM experimental support

### DIFF
--- a/docs/vm_launcher.md
+++ b/docs/vm_launcher.md
@@ -19,3 +19,7 @@ Install QEMU on macOS by running the following with `brew`:
 ```sh
 brew install qemu
 ```
+
+### Linux
+
+Install QEMU by [following the QEMU guide for your distribution](https://www.qemu.org/download/#linux).

--- a/packages/backend/src/api-impl.ts
+++ b/packages/backend/src/api-impl.ts
@@ -25,7 +25,7 @@ import { History } from './history';
 import * as containerUtils from './container-utils';
 import { Messages } from '/@shared/src/messages/Messages';
 import { telemetryLogger } from './extension';
-import { checkPrereqs, isLinux, isMac, getUidGid } from './machine-utils';
+import { checkPrereqs, isLinux, isMac, isWindows, getUidGid } from './machine-utils';
 import * as fs from 'node:fs';
 import path from 'node:path';
 import { getContainerEngine } from './container-utils';
@@ -284,6 +284,10 @@ export class BootcApiImpl implements BootcApi {
 
   async isMac(): Promise<boolean> {
     return isMac();
+  }
+
+  async isWindows(): Promise<boolean> {
+    return isWindows();
   }
 
   async getUidGid(): Promise<string> {

--- a/packages/backend/src/vm-manager.spec.ts
+++ b/packages/backend/src/vm-manager.spec.ts
@@ -1,0 +1,150 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { beforeEach, expect, test, vi } from 'vitest';
+import { createVMManager, stopCurrentVM } from './vm-manager';
+import { isLinux, isMac, isArm } from './machine-utils';
+import type { BootcBuildInfo } from '/@shared/src/models/bootc';
+import * as extensionApi from '@podman-desktop/api';
+import fs from 'node:fs';
+
+// Mock the functions from machine-utils
+vi.mock('./machine-utils', () => ({
+  isWindows: vi.fn(),
+  isLinux: vi.fn(),
+  isMac: vi.fn(),
+  isArm: vi.fn(),
+  isX86: vi.fn(),
+}));
+vi.mock('node:fs');
+vi.mock('@podman-desktop/api', async () => ({
+  process: {
+    exec: vi.fn(),
+  },
+  env: {
+    isLinux: vi.fn(),
+    isMac: vi.fn(),
+    isArm: vi.fn(),
+  },
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+test('createVMManager: should create a MacArmNativeVMManager for macOS ARM build', () => {
+  const build = {
+    id: '1',
+    image: 'test-image',
+    imageId: '1',
+    tag: 'latest',
+    type: ['raw'],
+    folder: '/path/to/folder',
+    arch: 'arm64',
+  } as BootcBuildInfo;
+
+  // Mock isMac and isArm to return true
+  vi.mocked(isMac).mockReturnValue(true);
+  vi.mocked(isArm).mockReturnValue(true);
+
+  const vmManager = createVMManager(build);
+  expect(vmManager.constructor.name).toBe('MacArmNativeVMManager');
+});
+
+test('createVMManager: should create a MacArmX86VMManager for macOS x86 build', () => {
+  const build = {
+    id: '2',
+    image: 'test-image',
+    imageId: '2',
+    tag: 'latest',
+    type: ['raw'],
+    folder: '/path/to/folder',
+    arch: 'amd64',
+  } as BootcBuildInfo;
+
+  // Mock isMac to return true
+  vi.mocked(isMac).mockReturnValue(true);
+  vi.mocked(isArm).mockReturnValue(true);
+
+  const vmManager = createVMManager(build);
+  expect(vmManager.constructor.name).toBe('MacArmX86VMManager');
+});
+
+test('createVMManager: should create a LinuxX86VMManager for Linux x86 build', () => {
+  const build = {
+    id: '2',
+    image: 'test-image',
+    imageId: '2',
+    tag: 'latest',
+    type: ['raw'],
+    folder: '/path/to/folder',
+    arch: 'amd64',
+  } as BootcBuildInfo;
+
+  // Mock isLinux to return true
+  vi.mocked(isMac).mockReturnValue(false);
+  vi.mocked(isArm).mockReturnValue(false);
+  vi.mocked(isLinux).mockReturnValue(true);
+
+  const vmManager = createVMManager(build);
+  expect(vmManager.constructor.name).toBe('LinuxX86VMManager');
+});
+
+test('createVMManager: should create a LinuxArmVMManager for Linux ARM build', () => {
+  const build = {
+    id: '2',
+    image: 'test-image',
+    imageId: '2',
+    tag: 'latest',
+    type: ['raw'],
+    folder: '/path/to/folder',
+    arch: 'arm64',
+  } as BootcBuildInfo;
+
+  // Mock isLinux to return true
+  vi.mocked(isMac).mockReturnValue(false);
+  vi.mocked(isArm).mockReturnValue(false);
+  vi.mocked(isLinux).mockReturnValue(true);
+
+  const vmManager = createVMManager(build);
+  expect(vmManager.constructor.name).toBe('LinuxArmVMManager');
+});
+
+test('createVMManager: should throw an error for unsupported OS/architecture', () => {
+  const build = {
+    id: '3',
+    image: 'test-image',
+    imageId: '3',
+    tag: 'latest',
+    type: ['raw'],
+    folder: '/path/to/folder',
+    arch: 'asdf',
+  } as BootcBuildInfo;
+
+  // Arch is explicitly set to an unsupported value (asdf)
+  expect(() => createVMManager(build)).toThrow('Unsupported OS or architecture');
+});
+
+test('stopCurrentVM: should call kill command with the pid from pidfile', async () => {
+  vi.spyOn(fs.promises, 'readFile').mockResolvedValueOnce('1234');
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  vi.spyOn(extensionApi.process, 'exec').mockResolvedValueOnce({ stdout: '' } as any);
+
+  await stopCurrentVM();
+  expect(extensionApi.process.exec).toHaveBeenCalledWith('sh', ['-c', 'kill -9 `cat /tmp/qemu-podman-desktop.pid`']);
+});

--- a/packages/frontend/src/Build.spec.ts
+++ b/packages/frontend/src/Build.spec.ts
@@ -93,6 +93,7 @@ const mockImageInspect = {
 
 const mockIsLinux = false;
 const mockIsMac = false;
+const mockIsWindows = false;
 
 vi.mock('./api/client', async () => {
   return {
@@ -108,6 +109,7 @@ vi.mock('./api/client', async () => {
       generateUniqueBuildID: vi.fn(),
       buildImage: vi.fn(),
       isMac: vi.fn().mockImplementation(() => mockIsMac),
+      isWindows: vi.fn().mockImplementation(() => mockIsWindows),
     },
     rpcBrowser: {
       subscribe: () => {

--- a/packages/frontend/src/lib/dashboard/Dashboard.spec.ts
+++ b/packages/frontend/src/lib/dashboard/Dashboard.spec.ts
@@ -52,6 +52,7 @@ vi.mock('../../api/client', async () => {
       listBootcImages: vi.fn(),
       pullImage: vi.fn(),
       isMac: vi.fn(),
+      isWindows: vi.fn(),
     },
     rpcBrowser: {
       subscribe: () => {

--- a/packages/frontend/src/lib/disk-image/DiskImageActions.spec.ts
+++ b/packages/frontend/src/lib/disk-image/DiskImageActions.spec.ts
@@ -25,7 +25,7 @@ vi.mock('/@/api/client', async () => {
   return {
     bootcClient: {
       deleteBuilds: vi.fn(),
-      isMac: vi.fn(),
+      isWindows: vi.fn(),
     },
     rpcBrowser: {
       subscribe: () => {
@@ -53,7 +53,7 @@ beforeEach(() => {
 });
 
 test('Renders Delete Build button', async () => {
-  vi.mocked(bootcClient.isMac).mockResolvedValue(false);
+  vi.mocked(bootcClient.isWindows).mockResolvedValue(false);
   render(DiskImageActions, { object: mockHistoryInfo });
 
   const deleteButton = screen.getAllByRole('button', { name: 'Delete Build' })[0];
@@ -61,7 +61,7 @@ test('Renders Delete Build button', async () => {
 });
 
 test('Test clicking on delete button', async () => {
-  vi.mocked(bootcClient.isMac).mockResolvedValue(false);
+  vi.mocked(bootcClient.isWindows).mockResolvedValue(false);
   render(DiskImageActions, { object: mockHistoryInfo });
 
   // spy on deleteBuild function
@@ -75,7 +75,7 @@ test('Test clicking on delete button', async () => {
 });
 
 test('Test clicking on logs button', async () => {
-  vi.mocked(bootcClient.isMac).mockResolvedValue(false);
+  vi.mocked(bootcClient.isWindows).mockResolvedValue(false);
   render(DiskImageActions, { object: mockHistoryInfo });
 
   // Click on logs button

--- a/packages/frontend/src/lib/disk-image/DiskImageActions.svelte
+++ b/packages/frontend/src/lib/disk-image/DiskImageActions.svelte
@@ -9,7 +9,7 @@ import { onMount } from 'svelte';
 export let object: BootcBuildInfo;
 export let detailed = false;
 
-let isMac = false;
+let isWindows = false;
 
 // Delete the build
 async function deleteBuild(): Promise<void> {
@@ -26,13 +26,13 @@ async function gotoVM(): Promise<void> {
 }
 
 onMount(async () => {
-  isMac = await bootcClient.isMac();
+  isWindows = await bootcClient.isWindows();
 });
 </script>
 
 <!-- Only show the Terminal button if object.arch actually exists or else we will not be able to pass in the architecture information to the build correctly.
 Only show if on macOS as well as that is the only option we support at the moment -->
-{#if object.arch && isMac}
+{#if object.arch && !isWindows}
   <ListItemButtonIcon title="Launch VM" onClick={() => gotoVM()} detailed={detailed} icon={faTerminal} />
 {/if}
 <ListItemButtonIcon title="Build Logs" onClick={() => gotoLogs()} detailed={detailed} icon={faFileAlt} />

--- a/packages/frontend/src/lib/disk-image/DiskImageColumnActions.spec.ts
+++ b/packages/frontend/src/lib/disk-image/DiskImageColumnActions.spec.ts
@@ -35,6 +35,7 @@ vi.mock('/@/api/client', async () => {
   return {
     bootcClient: {
       isMac: vi.fn(),
+      isWindows: vi.fn(),
     },
     rpcBrowser: {
       subscribe: () => {

--- a/packages/frontend/src/lib/disk-image/DiskImageDetails.spec.ts
+++ b/packages/frontend/src/lib/disk-image/DiskImageDetails.spec.ts
@@ -39,7 +39,7 @@ vi.mock('/@/api/client', async () => {
   return {
     bootcClient: {
       listHistoryInfo: vi.fn(),
-      isMac: vi.fn(),
+      isWindows: vi.fn(),
     },
     rpcBrowser: {
       subscribe: () => {
@@ -57,6 +57,7 @@ beforeEach(() => {
 
 test('Confirm renders disk image details', async () => {
   vi.mocked(bootcClient.listHistoryInfo).mockResolvedValue([image]);
+  vi.mocked(bootcClient.isWindows).mockResolvedValue(false);
 
   render(DiskImageDetails, { id: btoa(image.id) });
 

--- a/packages/frontend/src/lib/disk-image/DiskImageDetails.svelte
+++ b/packages/frontend/src/lib/disk-image/DiskImageDetails.svelte
@@ -22,11 +22,11 @@ let detailsPage: DetailsPage;
 
 let historyInfoUnsubscribe: Unsubscriber;
 
-let isMac = false;
+let isWindows = false;
 
 onMount(async () => {
-  // See if we are on mac or not for the VM tab
-  isMac = await bootcClient.isMac();
+  // See if we are on mac or linux or not for the VM tab
+  isWindows = await bootcClient.isWindows();
 
   // Subscribe to the history to update the details page
   const actualId = atob(id);
@@ -64,7 +64,7 @@ onDestroy(() => {
   <svelte:fragment slot="tabs">
     <Tab title="Summary" selected={isTabSelected($router.path, 'summary')} url={getTabUrl($router.path, 'summary')} />
     <Tab title="Build Log" selected={isTabSelected($router.path, 'build')} url={getTabUrl($router.path, 'build')} />
-    {#if isMac}
+    {#if !isWindows}
       <Tab
         title="Virtual Machine (Experimental)"
         selected={isTabSelected($router.path, 'vm')}

--- a/packages/frontend/src/lib/disk-image/DiskImageDetailsVirtualMachine.spec.ts
+++ b/packages/frontend/src/lib/disk-image/DiskImageDetailsVirtualMachine.spec.ts
@@ -36,6 +36,8 @@ vi.mock('/@/api/client', async () => {
       stopCurrentVM: vi.fn(),
       checkVMLaunchPrereqs: vi.fn(),
       launchVM: vi.fn(),
+      isMac: vi.fn(),
+      isWindows: vi.fn(),
     },
   };
 });

--- a/packages/frontend/src/lib/disk-image/DiskImagesList.spec.ts
+++ b/packages/frontend/src/lib/disk-image/DiskImagesList.spec.ts
@@ -53,6 +53,7 @@ vi.mock('/@/api/client', async () => {
       deleteBuilds: vi.fn(),
       telemetryLogUsage: vi.fn(),
       isMac: vi.fn(),
+      isWindows: vi.fn(),
     },
     rpcBrowser: {
       subscribe: () => {

--- a/packages/shared/src/BootcAPI.ts
+++ b/packages/shared/src/BootcAPI.ts
@@ -40,6 +40,7 @@ export abstract class BootcApi {
   abstract openLink(link: string): Promise<void>;
   abstract isLinux(): Promise<boolean>;
   abstract isMac(): Promise<boolean>;
+  abstract isWindows(): Promise<boolean>;
   abstract getUidGid(): Promise<string>;
   abstract getExamples(): Promise<ExamplesList>;
   abstract loadLogsFromFolder(folder: string): Promise<string>;


### PR DESCRIPTION
feat: add linux VM experimental support

### What does this PR do?

* Adds ability to test out VM for Linux users
* Arm and AMD64 support.
* Requires QEMU installed (there are prereqs as well as documentation
  that outlines it)

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

![Screenshot from 2024-12-16 13-10-31](https://github.com/user-attachments/assets/cc06d69f-6e2e-4e4b-a59c-0cc356b134ec)


### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/podman-desktop/extension-bootc/issues/878

### How to test this PR?

<!-- Please explain steps to reproduce -->

1. Be on Linux
2. Install QEMU (see documentation)
3. Build an image
4. Click on the Virtual Machine tab after building (or the Launch VM
   button).

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
