### PR TITLE
fix: e2e main workflow node setup step

### DIFF
--- a/.github/workflows/e2e-main.yaml
+++ b/.github/workflows/e2e-main.yaml
@@ -72,6 +72,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
+          working-directory: ./podman-desktop
           cache: 'pnpm'
 
       - name: Update podman


### PR DESCRIPTION
### What does this PR do?

Fixes e2e-main workflow failure at node setup step, by setting working-folder to correct location with pnpm-lock.yaml

### Screenshot / video of UI

<!-- If this PR is changing UI, please include 
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop 
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to reproduce -->
