### PR TITLE
chore: update vitest to support vite v6

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "prettier-plugin-svelte": "^3.3.2",
     "typescript": "5.7.2",
     "vite": "^6.0.3",
-    "vitest": "^2.0.2"
+    "vitest": "3.0.0-beta.2"
   },
   "dependencies": {
     "@xterm/addon-attach": "^0.11.0",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -114,7 +114,7 @@
     "prettier": "^3.4.2",
     "typescript": "5.7.2",
     "vite": "^6.0.3",
-    "vitest": "^2.0.2"
+    "vitest": "3.0.0-beta.2"
   },
   "dependencies": {
     "semver": "^7.6.3"

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -53,6 +53,6 @@
     "svelte-preprocess": "^6.0.3",
     "tailwindcss": "^3.4.16",
     "vite": "^6.0.3",
-    "vitest": "^2.0.2"
+    "vitest": "3.0.0-beta.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,7 +33,7 @@ importers:
         version: 8.14.0(eslint@8.57.1)(typescript@5.7.2)
       '@vitest/coverage-v8':
         specifier: ^2.0.2
-        version: 2.1.5(vitest@2.1.5(@types/node@20.17.10)(jsdom@25.0.1))
+        version: 2.1.5(vitest@3.0.0-beta.2(@types/node@20.17.10)(jiti@2.4.1)(jsdom@25.0.1)(yaml@2.6.1))
       autoprefixer:
         specifier: ^10.4.20
         version: 10.4.20(postcss@8.4.49)
@@ -83,8 +83,8 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3(@types/node@20.17.10)(jiti@2.4.1)(yaml@2.6.1)
       vitest:
-        specifier: ^2.0.2
-        version: 2.1.5(@types/node@20.17.10)(jsdom@25.0.1)
+        specifier: 3.0.0-beta.2
+        version: 3.0.0-beta.2(@types/node@20.17.10)(jiti@2.4.1)(jsdom@25.0.1)(yaml@2.6.1)
 
   packages/backend:
     dependencies:
@@ -106,7 +106,7 @@ importers:
         version: 6.21.0(eslint@8.57.1)(typescript@5.7.2)
       '@vitest/coverage-v8':
         specifier: ^2.0.2
-        version: 2.1.5(vitest@2.1.5(@types/node@20.17.6)(jsdom@25.0.1))
+        version: 2.1.5(vitest@3.0.0-beta.2(@types/node@20.17.6)(jiti@2.4.1)(jsdom@25.0.1)(yaml@2.6.1))
       '@xterm/addon-attach':
         specifier: ^0.11.0
         version: 0.11.0(@xterm/xterm@5.5.0)
@@ -150,8 +150,8 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3(@types/node@20.17.6)(jiti@2.4.1)(yaml@2.6.1)
       vitest:
-        specifier: ^2.0.2
-        version: 2.1.5(@types/node@20.17.6)(jsdom@25.0.1)
+        specifier: 3.0.0-beta.2
+        version: 3.0.0-beta.2(@types/node@20.17.6)(jiti@2.4.1)(jsdom@25.0.1)(yaml@2.6.1)
 
   packages/frontend:
     dependencies:
@@ -194,7 +194,7 @@ importers:
         version: 6.6.3
       '@testing-library/svelte':
         specifier: ^5.2.6
-        version: 5.2.6(svelte@5.14.2)(vite@6.0.3(@types/node@20.17.10)(jiti@2.4.1)(yaml@2.6.1))(vitest@2.1.5(@types/node@20.17.10)(jsdom@25.0.1))
+        version: 5.2.6(svelte@5.14.2)(vite@6.0.3(@types/node@20.17.10)(jiti@2.4.1)(yaml@2.6.1))(vitest@3.0.0-beta.2(@types/node@20.17.10)(jiti@2.4.1)(jsdom@25.0.1)(yaml@2.6.1))
       '@testing-library/user-event':
         specifier: ^14.5.1
         version: 14.5.2(@testing-library/dom@10.4.0)
@@ -256,8 +256,8 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3(@types/node@20.17.10)(jiti@2.4.1)(yaml@2.6.1)
       vitest:
-        specifier: ^2.0.2
-        version: 2.1.5(@types/node@20.17.10)(jsdom@25.0.1)
+        specifier: 3.0.0-beta.2
+        version: 3.0.0-beta.2(@types/node@20.17.10)(jiti@2.4.1)(jsdom@25.0.1)(yaml@2.6.1)
 
   tests/playwright:
     devDependencies:
@@ -1700,8 +1700,22 @@ packages:
   '@vitest/expect@2.1.5':
     resolution: {integrity: sha512-nZSBTW1XIdpZvEJyoP/Sy8fUg0b8od7ZpGDkTUcfJ7wz/VoZAFzFfLyxVxGFhUjJzhYqSbIpfMtl/+k/dpWa3Q==}
 
+  '@vitest/expect@3.0.0-beta.2':
+    resolution: {integrity: sha512-xdywwsqHOTZ66dBr8sQ+l3c0ZQs/wQY48fBRgLDrUqTU8OlDir6H1JMIOeV+Jb85Ov1XBGXBrSVlPDIo/fN5EQ==}
+
   '@vitest/mocker@2.1.5':
     resolution: {integrity: sha512-XYW6l3UuBmitWqSUXTNXcVBUCRytDogBsWuNXQijc00dtnU/9OqpXWp4OJroVrad/gLIomAq9aW8yWDBtMthhQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/mocker@3.0.0-beta.2':
+    resolution: {integrity: sha512-rSYrjKX8RwiKLw9MoZ8FDjos90C//AVphNVVYsv8QJn6brSkJLAOTFjTn13E8mF8kh3Bx8NKNgyDrx48ioJFXQ==}
     peerDependencies:
       msw: ^2.4.9
       vite: ^5.0.0
@@ -1714,17 +1728,32 @@ packages:
   '@vitest/pretty-format@2.1.5':
     resolution: {integrity: sha512-4ZOwtk2bqG5Y6xRGHcveZVr+6txkH7M2e+nPFd6guSoN638v/1XQ0K06eOpi0ptVU/2tW/pIU4IoPotY/GZ9fw==}
 
+  '@vitest/pretty-format@3.0.0-beta.2':
+    resolution: {integrity: sha512-vMCmIdShOz2vjMCyxk+SoexZxsIbwrRc/weTctKxnQAYv3NubehpwCOaT8nhirmYQtdW+8r079wz1s7cKxNmCA==}
+
   '@vitest/runner@2.1.5':
     resolution: {integrity: sha512-pKHKy3uaUdh7X6p1pxOkgkVAFW7r2I818vHDthYLvUyjRfkKOU6P45PztOch4DZarWQne+VOaIMwA/erSSpB9g==}
+
+  '@vitest/runner@3.0.0-beta.2':
+    resolution: {integrity: sha512-Ytyub2tBCGrROrGfVlB8SuWdQjFYzJTTR969CGJF/xkIgdkLE9SiQzBZy4td2VidypntLXAVHYjeGr75pvw93w==}
 
   '@vitest/snapshot@2.1.5':
     resolution: {integrity: sha512-zmYw47mhfdfnYbuhkQvkkzYroXUumrwWDGlMjpdUr4jBd3HZiV2w7CQHj+z7AAS4VOtWxI4Zt4bWt4/sKcoIjg==}
 
+  '@vitest/snapshot@3.0.0-beta.2':
+    resolution: {integrity: sha512-6INaNxXyYBmFGHhjmSyoz+/P3F+e6sHZPXLYt2OAa6Zt1v1O91FoGUTwdNHj2ASxMQeVpK/7snxNaeyr2INVOg==}
+
   '@vitest/spy@2.1.5':
     resolution: {integrity: sha512-aWZF3P0r3w6DiYTVskOYuhBc7EMc3jvn1TkBg8ttylFFRqNN2XGD7V5a4aQdk6QiUzZQ4klNBSpCLJgWNdIiNw==}
 
+  '@vitest/spy@3.0.0-beta.2':
+    resolution: {integrity: sha512-tSxQfS/wDWRtyx/a3smGuQr/YFaZk1iUsPbKkEvd6jIsrWBb747MSpdn9xfLgIhI68tXquCzruXiMQG0kHdILA==}
+
   '@vitest/utils@2.1.5':
     resolution: {integrity: sha512-yfj6Yrp0Vesw2cwJbP+cl04OC+IHFsuQsrsJBL9pyGeQXE56v1UAOQco+SR55Vf1nQzfV0QJg1Qum7AaWUwwYg==}
+
+  '@vitest/utils@3.0.0-beta.2':
+    resolution: {integrity: sha512-Jkib9LoI9Xm3gmzwI+9KgEAJVZNgJQFrR1RAyqBN7k9O3qezOTUjqyYBnvyz3UcPywygP1jEjZWBxUKx4ELpxw==}
 
   '@xterm/addon-attach@0.11.0':
     resolution: {integrity: sha512-JboCN0QAY6ZLY/SSB/Zl2cQ5zW1Eh4X3fH7BnuR1NB7xGRhzbqU2Npmpiw/3zFlxDaU88vtKzok44JKi2L2V2Q==}
@@ -3032,6 +3061,9 @@ packages:
   magic-string@0.30.12:
     resolution: {integrity: sha512-Ea8I3sQMVXr8JhN4z+H/d8zwo+tYDgHE9+5G4Wnrwhs0gaK9fXTKx0Tw5Xwsd/bCPTTZNRAdpyzvoeORe9LYpw==}
 
+  magic-string@0.30.17:
+    resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
+
   magicast@0.3.5:
     resolution: {integrity: sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==}
 
@@ -3944,6 +3976,11 @@ packages:
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
 
+  vite-node@3.0.0-beta.2:
+    resolution: {integrity: sha512-ofTf6cfRdL30Wbl9n/BX81EyIR5s4PReLmSurrxQ+koLaWUNOEo8E0lCM53OJkb8vpa2URM2nSrxZsIFyvY1rg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+
   vite@5.4.11:
     resolution: {integrity: sha512-c7jFQRklXua0mTzneGW9QVyxFjUgwcihC4bXEtujIo2ouWCe1Ajt/amn2PCxYnhYfd5k09JX3SB7OYWFKYqj8Q==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -4032,6 +4069,31 @@ packages:
       '@types/node': ^18.0.0 || >=20.0.0
       '@vitest/browser': 2.1.5
       '@vitest/ui': 2.1.5
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  vitest@3.0.0-beta.2:
+    resolution: {integrity: sha512-ZP0FVJ4tNJJOsjzZSuadEW0BPBgO7DMMen3mIE8TPPiPUMwz9YoS1U5bcqMYZ61r34xGsaYPe1h0l1MXt50f7g==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.0.0-beta.2
+      '@vitest/ui': 3.0.0-beta.2
       happy-dom: '*'
       jsdom: '*'
     peerDependenciesMeta:
@@ -5420,13 +5482,13 @@ snapshots:
       lodash: 4.17.21
       redent: 3.0.0
 
-  '@testing-library/svelte@5.2.6(svelte@5.14.2)(vite@6.0.3(@types/node@20.17.10)(jiti@2.4.1)(yaml@2.6.1))(vitest@2.1.5(@types/node@20.17.10)(jsdom@25.0.1))':
+  '@testing-library/svelte@5.2.6(svelte@5.14.2)(vite@6.0.3(@types/node@20.17.10)(jiti@2.4.1)(yaml@2.6.1))(vitest@3.0.0-beta.2(@types/node@20.17.10)(jiti@2.4.1)(jsdom@25.0.1)(yaml@2.6.1))':
     dependencies:
       '@testing-library/dom': 10.4.0
       svelte: 5.14.2
     optionalDependencies:
       vite: 6.0.3(@types/node@20.17.10)(jiti@2.4.1)(yaml@2.6.1)
-      vitest: 2.1.5(@types/node@20.17.10)(jsdom@25.0.1)
+      vitest: 3.0.0-beta.2(@types/node@20.17.10)(jiti@2.4.1)(jsdom@25.0.1)(yaml@2.6.1)
 
   '@testing-library/user-event@14.5.2(@testing-library/dom@10.4.0)':
     dependencies:
@@ -5715,7 +5777,7 @@ snapshots:
 
   '@ungap/structured-clone@1.2.0': {}
 
-  '@vitest/coverage-v8@2.1.5(vitest@2.1.5(@types/node@20.17.10)(jsdom@25.0.1))':
+  '@vitest/coverage-v8@2.1.5(vitest@3.0.0-beta.2(@types/node@20.17.10)(jiti@2.4.1)(jsdom@25.0.1)(yaml@2.6.1))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 0.2.3
@@ -5729,11 +5791,11 @@ snapshots:
       std-env: 3.8.0
       test-exclude: 7.0.1
       tinyrainbow: 1.2.0
-      vitest: 2.1.5(@types/node@20.17.10)(jsdom@25.0.1)
+      vitest: 3.0.0-beta.2(@types/node@20.17.10)(jiti@2.4.1)(jsdom@25.0.1)(yaml@2.6.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-v8@2.1.5(vitest@2.1.5(@types/node@20.17.6)(jsdom@25.0.1))':
+  '@vitest/coverage-v8@2.1.5(vitest@3.0.0-beta.2(@types/node@20.17.6)(jiti@2.4.1)(jsdom@25.0.1)(yaml@2.6.1))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 0.2.3
@@ -5747,7 +5809,7 @@ snapshots:
       std-env: 3.8.0
       test-exclude: 7.0.1
       tinyrainbow: 1.2.0
-      vitest: 2.1.5(@types/node@20.17.6)(jsdom@25.0.1)
+      vitest: 3.0.0-beta.2(@types/node@20.17.6)(jiti@2.4.1)(jsdom@25.0.1)(yaml@2.6.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -5758,13 +5820,12 @@ snapshots:
       chai: 5.1.2
       tinyrainbow: 1.2.0
 
-  '@vitest/mocker@2.1.5(vite@5.4.11(@types/node@20.17.10))':
+  '@vitest/expect@3.0.0-beta.2':
     dependencies:
-      '@vitest/spy': 2.1.5
-      estree-walker: 3.0.3
-      magic-string: 0.30.12
-    optionalDependencies:
-      vite: 5.4.11(@types/node@20.17.10)
+      '@vitest/spy': 3.0.0-beta.2
+      '@vitest/utils': 3.0.0-beta.2
+      chai: 5.1.2
+      tinyrainbow: 1.2.0
 
   '@vitest/mocker@2.1.5(vite@5.4.11(@types/node@20.17.6))':
     dependencies:
@@ -5774,7 +5835,27 @@ snapshots:
     optionalDependencies:
       vite: 5.4.11(@types/node@20.17.6)
 
+  '@vitest/mocker@3.0.0-beta.2(vite@6.0.3(@types/node@20.17.10)(jiti@2.4.1)(yaml@2.6.1))':
+    dependencies:
+      '@vitest/spy': 3.0.0-beta.2
+      estree-walker: 3.0.3
+      magic-string: 0.30.17
+    optionalDependencies:
+      vite: 6.0.3(@types/node@20.17.10)(jiti@2.4.1)(yaml@2.6.1)
+
+  '@vitest/mocker@3.0.0-beta.2(vite@6.0.3(@types/node@20.17.6)(jiti@2.4.1)(yaml@2.6.1))':
+    dependencies:
+      '@vitest/spy': 3.0.0-beta.2
+      estree-walker: 3.0.3
+      magic-string: 0.30.17
+    optionalDependencies:
+      vite: 6.0.3(@types/node@20.17.6)(jiti@2.4.1)(yaml@2.6.1)
+
   '@vitest/pretty-format@2.1.5':
+    dependencies:
+      tinyrainbow: 1.2.0
+
+  '@vitest/pretty-format@3.0.0-beta.2':
     dependencies:
       tinyrainbow: 1.2.0
 
@@ -5783,19 +5864,40 @@ snapshots:
       '@vitest/utils': 2.1.5
       pathe: 1.1.2
 
+  '@vitest/runner@3.0.0-beta.2':
+    dependencies:
+      '@vitest/utils': 3.0.0-beta.2
+      pathe: 1.1.2
+
   '@vitest/snapshot@2.1.5':
     dependencies:
       '@vitest/pretty-format': 2.1.5
       magic-string: 0.30.12
       pathe: 1.1.2
 
+  '@vitest/snapshot@3.0.0-beta.2':
+    dependencies:
+      '@vitest/pretty-format': 3.0.0-beta.2
+      magic-string: 0.30.17
+      pathe: 1.1.2
+
   '@vitest/spy@2.1.5':
+    dependencies:
+      tinyspy: 3.0.2
+
+  '@vitest/spy@3.0.0-beta.2':
     dependencies:
       tinyspy: 3.0.2
 
   '@vitest/utils@2.1.5':
     dependencies:
       '@vitest/pretty-format': 2.1.5
+      loupe: 3.1.2
+      tinyrainbow: 1.2.0
+
+  '@vitest/utils@3.0.0-beta.2':
+    dependencies:
+      '@vitest/pretty-format': 3.0.0-beta.2
       loupe: 3.1.2
       tinyrainbow: 1.2.0
 
@@ -7344,6 +7446,10 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
 
+  magic-string@0.30.17:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.0
+
   magicast@0.3.5:
     dependencies:
       '@babel/parser': 7.26.2
@@ -8200,24 +8306,6 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  vite-node@2.1.5(@types/node@20.17.10):
-    dependencies:
-      cac: 6.7.14
-      debug: 4.3.7
-      es-module-lexer: 1.5.4
-      pathe: 1.1.2
-      vite: 5.4.11(@types/node@20.17.10)
-    transitivePeerDependencies:
-      - '@types/node'
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-
   vite-node@2.1.5(@types/node@20.17.6):
     dependencies:
       cac: 6.7.14
@@ -8236,14 +8324,47 @@ snapshots:
       - supports-color
       - terser
 
-  vite@5.4.11(@types/node@20.17.10):
+  vite-node@3.0.0-beta.2(@types/node@20.17.10)(jiti@2.4.1)(yaml@2.6.1):
     dependencies:
-      esbuild: 0.21.5
-      postcss: 8.4.49
-      rollup: 4.26.0
-    optionalDependencies:
-      '@types/node': 20.17.10
-      fsevents: 2.3.3
+      cac: 6.7.14
+      debug: 4.4.0
+      es-module-lexer: 1.5.4
+      pathe: 1.1.2
+      vite: 6.0.3(@types/node@20.17.10)(jiti@2.4.1)(yaml@2.6.1)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vite-node@3.0.0-beta.2(@types/node@20.17.6)(jiti@2.4.1)(yaml@2.6.1):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.0
+      es-module-lexer: 1.5.4
+      pathe: 1.1.2
+      vite: 6.0.3(@types/node@20.17.6)(jiti@2.4.1)(yaml@2.6.1)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
 
   vite@5.4.11(@types/node@20.17.6):
     dependencies:
@@ -8280,42 +8401,6 @@ snapshots:
     optionalDependencies:
       vite: 6.0.3(@types/node@20.17.10)(jiti@2.4.1)(yaml@2.6.1)
 
-  vitest@2.1.5(@types/node@20.17.10)(jsdom@25.0.1):
-    dependencies:
-      '@vitest/expect': 2.1.5
-      '@vitest/mocker': 2.1.5(vite@5.4.11(@types/node@20.17.10))
-      '@vitest/pretty-format': 2.1.5
-      '@vitest/runner': 2.1.5
-      '@vitest/snapshot': 2.1.5
-      '@vitest/spy': 2.1.5
-      '@vitest/utils': 2.1.5
-      chai: 5.1.2
-      debug: 4.3.7
-      expect-type: 1.1.0
-      magic-string: 0.30.12
-      pathe: 1.1.2
-      std-env: 3.8.0
-      tinybench: 2.9.0
-      tinyexec: 0.3.1
-      tinypool: 1.0.2
-      tinyrainbow: 1.2.0
-      vite: 5.4.11(@types/node@20.17.10)
-      vite-node: 2.1.5(@types/node@20.17.10)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@types/node': 20.17.10
-      jsdom: 25.0.1
-    transitivePeerDependencies:
-      - less
-      - lightningcss
-      - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-
   vitest@2.1.5(@types/node@20.17.6)(jsdom@25.0.1):
     dependencies:
       '@vitest/expect': 2.1.5
@@ -8351,6 +8436,84 @@ snapshots:
       - sugarss
       - supports-color
       - terser
+
+  vitest@3.0.0-beta.2(@types/node@20.17.10)(jiti@2.4.1)(jsdom@25.0.1)(yaml@2.6.1):
+    dependencies:
+      '@vitest/expect': 3.0.0-beta.2
+      '@vitest/mocker': 3.0.0-beta.2(vite@6.0.3(@types/node@20.17.10)(jiti@2.4.1)(yaml@2.6.1))
+      '@vitest/pretty-format': 3.0.0-beta.2
+      '@vitest/runner': 3.0.0-beta.2
+      '@vitest/snapshot': 3.0.0-beta.2
+      '@vitest/spy': 3.0.0-beta.2
+      '@vitest/utils': 3.0.0-beta.2
+      chai: 5.1.2
+      debug: 4.4.0
+      expect-type: 1.1.0
+      magic-string: 0.30.17
+      pathe: 1.1.2
+      std-env: 3.8.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.1
+      tinypool: 1.0.2
+      tinyrainbow: 1.2.0
+      vite: 6.0.3(@types/node@20.17.10)(jiti@2.4.1)(yaml@2.6.1)
+      vite-node: 3.0.0-beta.2(@types/node@20.17.10)(jiti@2.4.1)(yaml@2.6.1)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 20.17.10
+      jsdom: 25.0.1
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vitest@3.0.0-beta.2(@types/node@20.17.6)(jiti@2.4.1)(jsdom@25.0.1)(yaml@2.6.1):
+    dependencies:
+      '@vitest/expect': 3.0.0-beta.2
+      '@vitest/mocker': 3.0.0-beta.2(vite@6.0.3(@types/node@20.17.6)(jiti@2.4.1)(yaml@2.6.1))
+      '@vitest/pretty-format': 3.0.0-beta.2
+      '@vitest/runner': 3.0.0-beta.2
+      '@vitest/snapshot': 3.0.0-beta.2
+      '@vitest/spy': 3.0.0-beta.2
+      '@vitest/utils': 3.0.0-beta.2
+      chai: 5.1.2
+      debug: 4.4.0
+      expect-type: 1.1.0
+      magic-string: 0.30.17
+      pathe: 1.1.2
+      std-env: 3.8.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.1
+      tinypool: 1.0.2
+      tinyrainbow: 1.2.0
+      vite: 6.0.3(@types/node@20.17.6)(jiti@2.4.1)(yaml@2.6.1)
+      vite-node: 3.0.0-beta.2(@types/node@20.17.6)(jiti@2.4.1)(yaml@2.6.1)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 20.17.6
+      jsdom: 25.0.1
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
 
   w3c-xmlserializer@5.0.0:
     dependencies:


### PR DESCRIPTION
### What does this PR do?

Vite was updated from v5 to v6, and vitest needs to be updated to match. vitest 2.2 added and then removed the support; 3.0 will add it but is still in beta until January.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes #1107.

### How to test this PR?

PR checks are enough.