### PR TITLE
chore: update Card to svelte 5

### DIFF
--- a/packages/frontend/src/lib/Card.svelte
+++ b/packages/frontend/src/lib/Card.svelte
@@ -1,10 +1,13 @@
 <script lang="ts">
+import type { Snippet } from 'svelte';
+
 interface Props {
   title: string;
   description?: string;
   href?: string;
+  children?: Snippet;
 }
-let { title, description, href }: Props = $props();
+let { title, description, href, children }: Props = $props();
 </script>
 
 <a class="no-underline" href={href}>
@@ -28,7 +31,7 @@ let { title, description, href }: Props = $props();
       </div>
     </div>
     <div class="flex overflow-hidden" role="region" aria-label="content">
-      <slot name="content" />
+      {@render children?.()}
     </div>
   </div>
 </a>

--- a/packages/frontend/src/lib/ExamplesCard.svelte
+++ b/packages/frontend/src/lib/ExamplesCard.svelte
@@ -64,7 +64,7 @@ $effect(() => {
 </script>
 
 <Card title={category.name}>
-  <div slot="content" class="w-full">
+  <div class="w-full">
     <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4 mt-4">
       {#each examples as example}
         <ExampleCard example={example} />


### PR DESCRIPTION
### What does this PR do?

Just updates the child rendering to svelte 5 to remove the build warning. Since this is the only slot I just removed the name for simplicity.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes #1206.

### How to test this PR?

PR tests pass, no UI regressions on examples page.