### PR TITLE
chore: add vars for prose markdown generation

### DIFF
--- a/packages/frontend/tailwind.config.cjs
+++ b/packages/frontend/tailwind.config.cjs
@@ -38,6 +38,22 @@ module.exports = {
       '5xl': '30px',
       '6xl': '36px',
     },
+    extend: {
+      typography: (theme) => ({
+        DEFAULT: {
+          css: {
+            color: 'var(--pd-details-body-text)',
+            '--tw-prose-body': 'var(--pd-details-body-text)',
+            '--tw-prose-bold': 'var(--pd-details-body-text)',
+            '--tw-prose-headings': 'var(--pd-details-body-text)',
+            '--tw-prose-quotes': 'var(--pd-details-body-text)',
+            '--tw-prose-hr': 'var(--pd-details-body-text)',
+            '--tw-prose-links': 'var(--pd-link)',
+            '--tw-prose-code': 'var(--pd-details-body-text)',
+          },
+        },
+      }),
+    },
     colors: {
       'charcoal': {
         600: '#27272a',


### PR DESCRIPTION
chore: add vars for prose markdown generation

### What does this PR do?

* Adds "prose" variable definitions in tailwind configuration for
  markdown rendering. Without this, the rendered markdown does not work
  in dark mode.
* See:
  https://github.com/containers/podman-desktop-extension-ai-lab/pull/1340
  regarding a similar issue

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

https://github.com/user-attachments/assets/76c89136-3966-42b8-855b-400b6fdb84ec




### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/podman-desktop/extension-bootc/issues/1122

### How to test this PR?

No test files needed.

View example details in both dark and light mode.

<!-- Please explain steps to reproduce -->

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
