### PR TITLE
chore: use env for windows and linux

### DIFF
--- a/packages/backend/src/machine-utils.spec.ts
+++ b/packages/backend/src/machine-utils.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 Red Hat, Inc.
+ * Copyright (C) 2024-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,6 +50,11 @@ vi.mock('@podman-desktop/api', async () => {
           dispose: vi.fn(),
         };
       },
+    },
+    env: {
+      isMac: true,
+      isLinux: false,
+      isWindows: false,
     },
     process: {
       exec: vi.fn(),

--- a/packages/backend/src/machine-utils.spec.ts
+++ b/packages/backend/src/machine-utils.spec.ts
@@ -51,11 +51,7 @@ vi.mock('@podman-desktop/api', async () => {
         };
       },
     },
-    env: {
-      isMac: true,
-      isLinux: false,
-      isWindows: false,
-    },
+    env: vi.fn(),
     process: {
       exec: vi.fn(),
     },

--- a/packages/backend/src/machine-utils.ts
+++ b/packages/backend/src/machine-utils.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 Red Hat, Inc.
+ * Copyright (C) 2024-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -165,14 +165,12 @@ function getCustomBinaryPath(): string | undefined {
   return extensionApi.configuration.getConfiguration('podman').get('binary.path');
 }
 
-const windows = os.platform() === 'win32';
 export function isWindows(): boolean {
-  return windows;
+  return env.isWindows;
 }
 
-const linux = os.platform() === 'linux';
 export function isLinux(): boolean {
-  return linux;
+  return env.isLinux;
 }
 
 export function isMac(): boolean {


### PR DESCRIPTION
### What does this PR do?

Just updates windows and linux to use PD env API instead of os.platform(), so that it is consistent with mac. Tests mock to mac for now, as they're not doing anything dependent on execution OS.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes #1207.

### How to test this PR?

PR checks.