### PR TITLE
fix: update setting nav test to match 1.16

### DIFF
--- a/packages/frontend/src/Navigation.spec.ts
+++ b/packages/frontend/src/Navigation.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 Red Hat, Inc.
+ * Copyright (C) 2024-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,11 +39,15 @@ test('Expect dashboard to be selected', async () => {
 
   const dashboard = screen.getByText('Dashboard');
   expect(dashboard).toBeInTheDocument();
-  expect(dashboard.parentElement).toHaveClass('text-[color:var(--pd-secondary-nav-text-selected)]');
+  expect(dashboard.parentElement?.parentElement).toHaveClass('text-[color:var(--pd-secondary-nav-text-selected)]');
 
   const diskImages = screen.getByText('Disk Images');
   expect(diskImages).toBeInTheDocument();
-  expect(diskImages.parentElement).not.toHaveClass('text-[color:var(--pd-secondary-nav-text-selected)]');
+  expect(diskImages.parentElement?.parentElement).not.toHaveClass('text-[color:var(--pd-secondary-nav-text-selected)]');
+
+  const examples = screen.getByText('Examples');
+  expect(examples).toBeInTheDocument();
+  expect(examples.parentElement?.parentElement).not.toHaveClass('text-[color:var(--pd-secondary-nav-text-selected)]');
 });
 
 test('Expect disk images to be selected', async () => {
@@ -51,9 +55,29 @@ test('Expect disk images to be selected', async () => {
 
   const dashboard = screen.getByText('Dashboard');
   expect(dashboard).toBeInTheDocument();
-  expect(dashboard.parentElement).not.toHaveClass('text-[color:var(--pd-secondary-nav-text-selected)]');
+  expect(dashboard.parentElement?.parentElement).not.toHaveClass('text-[color:var(--pd-secondary-nav-text-selected)]');
 
   const diskImages = screen.getByText('Disk Images');
   expect(diskImages).toBeInTheDocument();
-  expect(diskImages.parentElement).toHaveClass('text-[color:var(--pd-secondary-nav-text-selected)]');
+  expect(diskImages.parentElement?.parentElement).toHaveClass('text-[color:var(--pd-secondary-nav-text-selected)]');
+
+  const examples = screen.getByText('Examples');
+  expect(examples).toBeInTheDocument();
+  expect(examples.parentElement?.parentElement).not.toHaveClass('text-[color:var(--pd-secondary-nav-text-selected)]');
+});
+
+test('Expect examples to be selected', async () => {
+  render(Navigation, { meta: { url: '/examples' } as TinroRouteMeta });
+
+  const dashboard = screen.getByText('Dashboard');
+  expect(dashboard).toBeInTheDocument();
+  expect(dashboard.parentElement?.parentElement).not.toHaveClass('text-[color:var(--pd-secondary-nav-text-selected)]');
+
+  const diskImages = screen.getByText('Disk Images');
+  expect(diskImages).toBeInTheDocument();
+  expect(diskImages.parentElement?.parentElement).not.toHaveClass('text-[color:var(--pd-secondary-nav-text-selected)]');
+
+  const examples = screen.getByText('Examples');
+  expect(examples).toBeInTheDocument();
+  expect(examples.parentElement?.parentElement).toHaveClass('text-[color:var(--pd-secondary-nav-text-selected)]');
 });


### PR DESCRIPTION
### What does this PR do?

Tests are checking that when you're at each route, the corresponding nav item (and only that) is selected in the navigation. SettingsNavItem added an extra div in the hierarchy so test s checking the wrong div.

Ideally SettingsNavItem would have aria labels, and the test would look at more of the hierarchy - but it was only a minute to find the problem, fix the test, and add the missing test for examples. If it happens again we can do something better but for now just update the test (and add the missing paths).

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes #1235.

### How to test this PR?

PR test passes.