### PR TITLE
chore: update rpc message proxy and dispose correctly

### DIFF
--- a/packages/backend/src/extension.ts
+++ b/packages/backend/src/extension.ts
@@ -97,6 +97,8 @@ export async function activate(extensionContext: ExtensionContext): Promise<void
 
   // Register the 'api' for the webview to communicate to the backend
   const rpcExtension = new RpcExtension(panel.webview);
+  extensionContext.subscriptions.push(rpcExtension);
+
   const bootcApi = new BootcApiImpl(extensionContext, panel.webview);
   rpcExtension.registerInstance<BootcApiImpl>(BootcApiImpl, bootcApi);
 


### PR DESCRIPTION
### What does this PR do?

The RPC message proxy should be disposed on shutdown. This change just disposes it properly, and drops the timeout down to 5s (aligns with AI Lab change, may also help with a timeout during shutdown).

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Possibly the cause of https://github.com/podman-desktop/podman-desktop/issues/10926.

Fixes #1263.

### How to test this PR?

Try to reproduce https://github.com/podman-desktop/podman-desktop/issues/10926.