### PR TITLE
fix: create storage path

### DIFF
--- a/packages/backend/src/extension.ts
+++ b/packages/backend/src/extension.ts
@@ -47,6 +47,7 @@ export async function activate(extensionContext: ExtensionContext): Promise<void
 
   telemetryLogger.logUsage('start');
 
+  await fs.promises.mkdir(extensionContext.storagePath, { recursive: true });
   const history = new History(extensionContext.storagePath);
   await history.loadFile();
 


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

Create storage path before to watch a file inside it, to avoid the app crash 

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/10926

### How to test this PR?

