### PR TITLE
chore: fix bootc label colouring on dark / light mode

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -76,8 +76,8 @@
           "badge": {
             "label": "bootc",
             "color": {
-              "dark": "bg-sky-300",
-              "light": "bg-sky-300"
+              "dark": "#7dd3fc",
+              "light": "#7dd3fc"
             }
           }
         }


### PR DESCRIPTION
chore: fix bootc label colouring on dark / light mode

### What does this PR do?

Fixes the colour showing in dark / light mode on the image page. As
before it was not picking up the tailwind-specific colour.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

![Screenshot 2025-02-05 at 3 21 18 PM](https://github.com/user-attachments/assets/402d87fd-a72a-49db-8fce-3a48e040e8e6)

https://github.com/user-attachments/assets/9a8e3953-5eda-4377-ad98-4cd51d8d69d4



### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/podman-desktop/extension-bootc/issues/1174

### How to test this PR?

<!-- Please explain steps to reproduce -->

1.Pull a bootc test image
2. See that the label shows now

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
