### PR TITLE
chore: svelte 5 disk image columns and details

### DIFF
--- a/packages/frontend/src/lib/disk-image/DiskImageActions.svelte
+++ b/packages/frontend/src/lib/disk-image/DiskImageActions.svelte
@@ -6,10 +6,13 @@ import { router } from 'tinro';
 import { bootcClient } from '/@/api/client';
 import { onMount } from 'svelte';
 
-export let object: BootcBuildInfo;
-export let detailed = false;
+interface Props {
+  object: BootcBuildInfo;
+  detailed?: boolean;
+}
 
-let isWindows = false;
+let { object, detailed = false }: Props = $props();
+let isWindows = $state(false);
 
 // Delete the build
 async function deleteBuild(): Promise<void> {

--- a/packages/frontend/src/lib/disk-image/DiskImageColumnActions.svelte
+++ b/packages/frontend/src/lib/disk-image/DiskImageColumnActions.svelte
@@ -1,8 +1,0 @@
-<script lang="ts">
-import type { BootcBuildInfo } from '/@shared/src/models/bootc';
-import DiskImageActions from './DiskImageActions.svelte';
-
-export let object: BootcBuildInfo;
-</script>
-
-<DiskImageActions object={object} on:update />

--- a/packages/frontend/src/lib/disk-image/DiskImageConnectionStatus.svelte
+++ b/packages/frontend/src/lib/disk-image/DiskImageConnectionStatus.svelte
@@ -1,7 +1,10 @@
 <script lang="ts">
 import Label from '/@/lib/upstream/Label.svelte';
 
-export let status: string;
+interface Props {
+  status: string;
+}
+let { status }: Props = $props();
 
 function getClassColor(): string {
   if (status.includes('VM stopped') || status.includes('VM error') || status.includes('VM launch error')) {

--- a/packages/frontend/src/lib/disk-image/DiskImageDetails.svelte
+++ b/packages/frontend/src/lib/disk-image/DiskImageDetails.svelte
@@ -14,15 +14,15 @@ import DiskImageDetailsVirtualMachine from './DiskImageDetailsVirtualMachine.sve
 import type { Unsubscriber } from 'svelte/store';
 import { bootcClient } from '/@/api/client';
 
-export let id: string;
+interface Props {
+  id: string;
+}
+let { id }: Props = $props();
 
-let diskImage: BootcBuildInfo;
-
-let detailsPage: DetailsPage;
-
-let historyInfoUnsubscribe: Unsubscriber;
-
-let isWindows = false;
+let diskImage = $state<BootcBuildInfo>();
+let detailsPage = $state<DetailsPage>();
+let historyInfoUnsubscribe = $state<Unsubscriber>();
+let isWindows = $state(false);
 
 onMount(async () => {
   // See if we are on mac or linux or not for the VM tab

--- a/packages/frontend/src/lib/disk-image/DiskImageDetailsBuild.svelte
+++ b/packages/frontend/src/lib/disk-image/DiskImageDetailsBuild.svelte
@@ -9,20 +9,23 @@ import { router } from 'tinro';
 import { bootcClient } from '/@/api/client';
 import { getTerminalTheme } from '/@/lib/upstream/terminal-theme';
 
-export let folder: string | undefined;
+interface Props {
+  folder?: string;
+}
+let { folder }: Props = $props();
 
 // Log
-let logsXtermDiv: HTMLDivElement;
-let noLogs = true;
-let previousLogs: string = '';
-const refreshInterval = 2000;
+let logsXtermDiv = $state<HTMLDivElement>();
+let noLogs = $state(true);
+let previousLogs = $state('');
+const refreshInterval = $state(2000);
 
 // Terminal resize
-let resizeObserver: ResizeObserver;
-let termFit: FitAddon;
+let resizeObserver = $state<ResizeObserver>();
+let termFit = $state<FitAddon>();
 
-let logsTerminal: Terminal;
-let logInterval: NodeJS.Timeout;
+let logsTerminal = $state<Terminal>();
+let logInterval = $state<NodeJS.Timeout>();
 
 async function fetchFolderLogs(): Promise<void> {
   if (!folder) {
@@ -37,7 +40,7 @@ async function fetchFolderLogs(): Promise<void> {
   if (logs !== previousLogs) {
     // Write only the new logs to the log
     const newLogs = logs.slice(previousLogs.length);
-    logsTerminal.write(newLogs);
+    logsTerminal?.write(newLogs);
     previousLogs = logs; // Update the stored logs
     noLogs = false; // Make sure that the logs are visible
   }
@@ -71,7 +74,7 @@ async function refreshTerminal(): Promise<void> {
 
   // Call fit addon each time we resize the window
   window.addEventListener('resize', () => {
-    termFit.fit();
+    termFit?.fit();
   });
   termFit.fit();
 }
@@ -94,12 +97,16 @@ onMount(async () => {
   });
 
   // Observe the terminal div
-  resizeObserver.observe(logsXtermDiv);
+  if (logsXtermDiv) {
+    resizeObserver.observe(logsXtermDiv);
+  }
 });
 
 onDestroy(() => {
   // Cleanup the observer on destroy
-  resizeObserver?.unobserve(logsXtermDiv);
+  if (logsXtermDiv) {
+    resizeObserver?.unobserve(logsXtermDiv);
+  }
 
   // Clear the interval when the component is destroyed
   clearInterval(logInterval);

--- a/packages/frontend/src/lib/disk-image/DiskImageDetailsSummary.svelte
+++ b/packages/frontend/src/lib/disk-image/DiskImageDetailsSummary.svelte
@@ -5,7 +5,10 @@ import type { BootcBuildInfo } from '/@shared/src/models/bootc';
 import Cell from '/@/lib/upstream/DetailsCell.svelte';
 import Link from '../Link.svelte';
 
-export let image: BootcBuildInfo | undefined;
+interface Props {
+  image?: BootcBuildInfo;
+}
+let { image }: Props = $props();
 </script>
 
 <Table>

--- a/packages/frontend/src/lib/disk-image/DiskImagesList.svelte
+++ b/packages/frontend/src/lib/disk-image/DiskImagesList.svelte
@@ -2,13 +2,13 @@
 import { onMount } from 'svelte';
 import type { BootcBuildInfo } from '/@shared/src/models/bootc';
 import { faTrash } from '@fortawesome/free-solid-svg-icons';
-import DiskImageColumnActions from './DiskImageColumnActions.svelte';
+import DiskImageColumnActions from './columns/Actions.svelte';
 import { bootcClient } from '/@/api/client';
 import BootcStatus from '../BootcStatus.svelte';
 import { searchPattern, filtered } from '../../stores/historyInfo';
 import DiskImageIcon from '../DiskImageIcon.svelte';
-import DiskImageColumnFolder from './DiskImageColumnFolder.svelte';
-import DiskImageColumnImage from './DiskImageColumnImage.svelte';
+import DiskImageColumnFolder from './columns/Folder.svelte';
+import DiskImageColumnImage from './columns/Image.svelte';
 import {
   Button,
   Table,
@@ -21,11 +21,16 @@ import {
 import DiskImageEmptyScreen from './DiskImageEmptyScreen.svelte';
 import { gotoBuild } from '../navigation';
 
-// Search functionality
-export let searchTerm = '';
-$: searchPattern.set(searchTerm);
+interface Props {
+  searchTerm?: string;
+}
+let { searchTerm = '' }: Props = $props();
 
-let history: BootcBuildInfoWithSelected[] = [];
+$effect(() => {
+  searchPattern.set(searchTerm);
+});
+
+let history = $state<BootcBuildInfoWithSelected[]>([]);
 
 interface BootcBuildInfoWithSelected extends BootcBuildInfo {
   selected: boolean;
@@ -38,7 +43,8 @@ onMount(() => {
 });
 
 // Bulk delete the selected builds
-let bulkDeleteInProgress = false;
+let bulkDeleteInProgress = $state(false);
+
 async function deleteSelectedBuilds(): Promise<void> {
   const selected = history.filter(history => history.selected);
   if (selected.length === 0) {
@@ -53,8 +59,8 @@ async function deleteSelectedBuilds(): Promise<void> {
   bulkDeleteInProgress = false;
 }
 
-let selectedItemsNumber: number;
-let table: Table;
+let selectedItemsNumber = $state<number>(0);
+let table = $state<Table>();
 
 // COLUMNS
 let statusColumn = new TableColumn<BootcBuildInfo>('Status', {

--- a/packages/frontend/src/lib/disk-image/columns/Actions.spec.ts
+++ b/packages/frontend/src/lib/disk-image/columns/Actions.spec.ts
@@ -18,7 +18,7 @@
 import { beforeEach, vi, test, expect } from 'vitest';
 import type { BootcBuildInfo } from '/@shared/src/models/bootc';
 import { screen, render } from '@testing-library/svelte';
-import DiskImageColumnActions from '/@/lib/disk-image/DiskImageColumnActions.svelte';
+import DiskImageColumnActions from '/@/lib/disk-image/columns/Actions.svelte';
 import type { Subscriber } from '/@shared/src/messages/MessageProxy';
 
 const mockHistoryInfo: BootcBuildInfo = {

--- a/packages/frontend/src/lib/disk-image/columns/Actions.svelte
+++ b/packages/frontend/src/lib/disk-image/columns/Actions.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+import DiskImageActions from '../DiskImageActions.svelte';
+import type { Props } from './props';
+
+let { object }: Props = $props();
+</script>
+
+<DiskImageActions object={object} />

--- a/packages/frontend/src/lib/disk-image/columns/Folder.spec.ts
+++ b/packages/frontend/src/lib/disk-image/columns/Folder.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 Red Hat, Inc.
+ * Copyright (C) 2024-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,10 +15,11 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { test, expect } from 'vitest';
+import { beforeEach, vi, test, expect } from 'vitest';
 import type { BootcBuildInfo } from '/@shared/src/models/bootc';
 import { screen, render } from '@testing-library/svelte';
-import DiskImageColumnImage from './DiskImageColumnImage.svelte';
+import DiskImageColumnFolder from './Folder.svelte';
+import type { Subscriber } from '/@shared/src/messages/MessageProxy';
 
 const mockHistoryInfo: BootcBuildInfo = {
   id: 'name1',
@@ -32,20 +33,28 @@ const mockHistoryInfo: BootcBuildInfo = {
   status: 'running',
 };
 
-test('Expect to render as name:tag', async () => {
-  render(DiskImageColumnImage, { object: mockHistoryInfo });
-
-  const name = screen.getByText('image1:latest');
-  expect(name).not.toBeNull();
+vi.mock('/@/api/client', async () => {
+  return {
+    rpcBrowser: {
+      subscribe: (): Subscriber => {
+        return {
+          unsubscribe: (): void => {},
+        };
+      },
+    },
+  };
 });
 
-test('Expect click goes to details page', async () => {
-  render(DiskImageColumnImage, { object: mockHistoryInfo });
+beforeEach(() => {
+  vi.clearAllMocks();
+});
 
-  const name = screen.getByText('image1:latest');
-  expect(name).not.toBeNull();
+test('Expect to render folder column with a button to open the folder', async () => {
+  render(DiskImageColumnFolder, { object: mockHistoryInfo });
 
-  name.click();
+  const folder = screen.getByText('/foo/image1');
+  expect(folder).not.toBeNull();
 
-  expect(window.location.href).toContain('/summary');
+  // Expect button to be there with a link to the build
+  expect(screen.getByRole('link', { name: '/foo/image1' })).not.toBeNull();
 });

--- a/packages/frontend/src/lib/disk-image/columns/Folder.svelte
+++ b/packages/frontend/src/lib/disk-image/columns/Folder.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
 import Link from '/@/lib/Link.svelte';
-import type { BootcBuildInfo } from '/@shared/src/models/bootc';
+import type { Props } from './props';
 
-export let object: BootcBuildInfo;
+let { object }: Props = $props();
 </script>
 
 <div class="text-[var(--pd-table-body-text)] overflow-hidden text-ellipsis">

--- a/packages/frontend/src/lib/disk-image/columns/Image.spec.ts
+++ b/packages/frontend/src/lib/disk-image/columns/Image.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024-2025 Red Hat, Inc.
+ * Copyright (C) 2024 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,11 +15,10 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { beforeEach, vi, test, expect } from 'vitest';
+import { test, expect } from 'vitest';
 import type { BootcBuildInfo } from '/@shared/src/models/bootc';
 import { screen, render } from '@testing-library/svelte';
-import DiskImageColumnFolder from './DiskImageColumnFolder.svelte';
-import type { Subscriber } from '/@shared/src/messages/MessageProxy';
+import DiskImageColumnImage from './Image.svelte';
 
 const mockHistoryInfo: BootcBuildInfo = {
   id: 'name1',
@@ -33,28 +32,20 @@ const mockHistoryInfo: BootcBuildInfo = {
   status: 'running',
 };
 
-vi.mock('/@/api/client', async () => {
-  return {
-    rpcBrowser: {
-      subscribe: (): Subscriber => {
-        return {
-          unsubscribe: (): void => {},
-        };
-      },
-    },
-  };
+test('Expect to render as name:tag', async () => {
+  render(DiskImageColumnImage, { object: mockHistoryInfo });
+
+  const name = screen.getByText('image1:latest');
+  expect(name).not.toBeNull();
 });
 
-beforeEach(() => {
-  vi.clearAllMocks();
-});
+test('Expect click goes to details page', async () => {
+  render(DiskImageColumnImage, { object: mockHistoryInfo });
 
-test('Expect to render folder column with a button to open the folder', async () => {
-  render(DiskImageColumnFolder, { object: mockHistoryInfo });
+  const name = screen.getByText('image1:latest');
+  expect(name).not.toBeNull();
 
-  const folder = screen.getByText('/foo/image1');
-  expect(folder).not.toBeNull();
+  name.click();
 
-  // Expect button to be there with a link to the build
-  expect(screen.getByRole('link', { name: '/foo/image1' })).not.toBeNull();
+  expect(window.location.href).toContain('/summary');
 });

--- a/packages/frontend/src/lib/disk-image/columns/Image.svelte
+++ b/packages/frontend/src/lib/disk-image/columns/Image.svelte
@@ -1,15 +1,15 @@
 <script lang="ts">
 import { router } from 'tinro';
-import type { BootcBuildInfo } from '/@shared/src/models/bootc';
+import type { Props } from './props';
 
-export let object: BootcBuildInfo;
+let { object }: Props = $props();
 
 function openDetails(): void {
   router.goto(`/disk-image/${btoa(object.id)}/summary`);
 }
 </script>
 
-<button class="hover:cursor-pointer flex flex-col max-w-full" on:click={openDetails}>
+<button class="hover:cursor-pointer flex flex-col max-w-full" onclick={openDetails}>
   <div class="text-[var(--pd-table-body-text-highlight)] max-w-full overflow-hidden text-ellipsis">
     {object.image}:{object.tag}
   </div>

--- a/packages/frontend/src/lib/disk-image/columns/props.ts
+++ b/packages/frontend/src/lib/disk-image/columns/props.ts
@@ -1,0 +1,22 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { BootcBuildInfo } from '/@shared/src/models/bootc';
+
+export interface Props {
+  object: BootcBuildInfo;
+}


### PR DESCRIPTION
### What does this PR do?

Moves disk image columns and details pages to Svelte 5.

Column files are reorganized into /columns folder as discussed in https://github.com/podman-desktop/podman-desktop/issues/11035.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Part of #1295.

### How to test this PR?

PR checks, basic build list validation.