### PR TITLE
chore: missing rpc init

### DIFF
--- a/packages/backend/src/extension.ts
+++ b/packages/backend/src/extension.ts
@@ -98,6 +98,7 @@ export async function activate(extensionContext: ExtensionContext): Promise<void
 
   // Register the 'api' for the webview to communicate to the backend
   const rpcExtension = new RpcExtension(panel.webview);
+  rpcExtension.init();
   extensionContext.subscriptions.push(rpcExtension);
 
   const bootcApi = new BootcApiImpl(extensionContext, panel.webview);


### PR DESCRIPTION
### What does this PR do?

With the multi-channel RPC in #1300 we switched from automatic init via constructor to requiring init() to be called explicitly, I just missed committing this one critical line.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes #1301.

### How to test this PR?

See issue, just check examples or builds page appears.