### PR TITLE
feat: add anaconda iso module enable / disable

### DIFF
--- a/packages/backend/src/build-disk-image.spec.ts
+++ b/packages/backend/src/build-disk-image.spec.ts
@@ -561,3 +561,24 @@ test('test building with a buildConfig JSON file that a temporary file for build
     expect(options.HostConfig.Binds[2]).toContain('config.json:ro');
   }
 });
+
+test('expect createBuildConfigJSON to work with anaconda iso modules being enabled / dsiabled', async () => {
+  const buildConfig = {
+    anacondaIsoInstallerModules: {
+      enable: ['test-module', 'test-module2'],
+      disable: ['test-module3', 'test-module4'],
+    },
+  } as BuildConfig;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const buildConfigJson: Record<string, any> = createBuildConfigJSON(buildConfig);
+  expect(buildConfigJson).toBeDefined();
+
+  // Expect enable to contain test-module and 2
+  expect(buildConfigJson.customizations.installer.modules.enable).toContain('test-module');
+  expect(buildConfigJson.customizations.installer.modules.enable).toContain('test-module2');
+
+  // Expect disable to contain test-module3 and 4
+  expect(buildConfigJson.customizations.installer.modules.disable).toContain('test-module3');
+  expect(buildConfigJson.customizations.installer.modules.disable).toContain('test-module4');
+});

--- a/packages/backend/src/build-disk-image.spec.ts
+++ b/packages/backend/src/build-disk-image.spec.ts
@@ -562,7 +562,7 @@ test('test building with a buildConfig JSON file that a temporary file for build
   }
 });
 
-test('expect createBuildConfigJSON to work with anaconda iso modules being enabled / dsiabled', async () => {
+test('expect createBuildConfigJSON to work with anaconda iso modules being enabled / disabled', async () => {
   const buildConfig = {
     anacondaIsoInstallerModules: {
       enable: ['test-module', 'test-module2'],

--- a/packages/backend/src/build-disk-image.ts
+++ b/packages/backend/src/build-disk-image.ts
@@ -529,7 +529,10 @@ export function createBuildConfigJSON(buildConfig: BuildConfig): Record<string, 
   }
   So we make sure that we put it in the correct modules section
   */
-  if (buildConfig.anacondaIsoInstallerModules) {
+  if (
+    buildConfig.anacondaIsoInstallerModules &&
+    (buildConfig.anacondaIsoInstallerModules.enable.length > 0 || buildConfig)
+  ) {
     config.installer = {
       modules: {
         enable: buildConfig.anacondaIsoInstallerModules.enable,

--- a/packages/backend/src/build-disk-image.ts
+++ b/packages/backend/src/build-disk-image.ts
@@ -511,6 +511,33 @@ export function createBuildConfigJSON(buildConfig: BuildConfig): Record<string, 
     config.kernel = buildConfig.kernel;
   }
 
+  /*
+  For anaconda modules, it'll be a bit different, within the JSON it's setup as:
+  {
+    "customizations": {
+      "installer": {
+        "modules": {
+          "enable": [
+            "org.fedoraproject.Anaconda.Modules.Localization"
+          ],
+          "disable": [
+            "org.fedoraproject.Anaconda.Modules.Users"
+          ]
+        }
+      }
+    }
+  }
+  So we make sure that we put it in the correct modules section
+  */
+  if (buildConfig.anacondaIsoInstallerModules) {
+    config.installer = {
+      modules: {
+        enable: buildConfig.anacondaIsoInstallerModules.enable,
+        disable: buildConfig.anacondaIsoInstallerModules.disable,
+      },
+    };
+  }
+
   return { customizations: config };
 }
 

--- a/packages/frontend/src/Build.spec.ts
+++ b/packages/frontend/src/Build.spec.ts
@@ -845,3 +845,29 @@ test('confirm successful build goes to logs', async () => {
   await userEvent.click(build);
   expect(router.goto).toHaveBeenCalledWith(`/disk-image/bmFtZTE=/build`);
 });
+
+test('expect anaconda modules ISO section to be shown', async () => {
+  vi.mocked(bootcClient.inspectImage).mockResolvedValue(mockImageInspect);
+  vi.mocked(bootcClient.listHistoryInfo).mockResolvedValue(mockHistoryInfo);
+  vi.mocked(bootcClient.listBootcImages).mockResolvedValue(mockBootcImages);
+  vi.mocked(bootcClient.buildExists).mockResolvedValue(false);
+  vi.mocked(bootcClient.checkPrereqs).mockResolvedValue(undefined);
+  render(Build);
+
+  // Wait until children length is 2 meaning it's fully rendered / propagated the changes
+  await vi.waitFor(() => {
+    if (screen.getByLabelText('image-select')?.children.length !== 2) {
+      throw new Error();
+    }
+  });
+
+  // Find the "build-config-options" aria-label span and click it
+  const buildConfigOptions = screen.getByLabelText('interactive-build-config-options');
+  expect(buildConfigOptions).toBeDefined();
+  await userEvent.click(buildConfigOptions);
+
+  // Expect anaconda modules to be shown
+  // Wait for Anaconda ISO installer modules to be shown (span)
+  const anacondaModules = screen.getByLabelText('anaconda-iso-installer-module-title');
+  expect(anacondaModules).toBeDefined();
+});

--- a/packages/frontend/src/Build.svelte
+++ b/packages/frontend/src/Build.svelte
@@ -10,7 +10,12 @@ import {
   faPlusCircle,
 } from '@fortawesome/free-solid-svg-icons';
 import { bootcClient } from './api/client';
-import type { BootcBuildInfo, BuildType, BuildConfig } from '/@shared/src/models/bootc';
+import type {
+  BootcBuildInfo,
+  BuildType,
+  BuildConfig,
+  BuildConfigAnacondaIsoInstallerModules,
+} from '/@shared/src/models/bootc';
 import Fa from 'svelte-fa';
 import { onMount } from 'svelte';
 import type { ImageInfo, ManifestInspectInfo } from '@podman-desktop/api';
@@ -68,6 +73,12 @@ let buildConfigUsers: { name: string; password: string; key: string; groups: str
 ];
 let buildConfigFilesystems: { mountpoint: string; minsize: string }[] = [{ mountpoint: '', minsize: '' }];
 let buildConfigKernelArguments: string;
+
+// ISO related, anaconda installer modules
+let buildConfigAnacondaIsoInstallerModules: BuildConfigAnacondaIsoInstallerModules = {
+  enable: [''],
+  disable: [''],
+};
 
 // Show/hide advanced options
 let showAdvanced = false; // State to show/hide advanced options
@@ -249,6 +260,7 @@ async function buildBootcImage(): Promise<void> {
     kernel: {
       append: buildConfigKernelArguments,
     },
+    anacondaIsoInstallerModules: buildConfigAnacondaIsoInstallerModules,
   }) as BuildConfig;
 
   const buildOptions: BootcBuildInfo = {
@@ -361,6 +373,26 @@ function addFilesystem(): void {
 
 function deleteFilesystem(index: number): void {
   buildConfigFilesystems = buildConfigFilesystems.filter((_, i) => i !== index);
+}
+
+function addEnabledAnacondaInstallerModule(): void {
+  buildConfigAnacondaIsoInstallerModules.enable = [...buildConfigAnacondaIsoInstallerModules.enable, ''];
+}
+
+function addDisabledAnacondaInstallerModule(): void {
+  buildConfigAnacondaIsoInstallerModules.disable = [...buildConfigAnacondaIsoInstallerModules.disable, ''];
+}
+
+function deleteEnabledAnacondaInstallerModule(index: number): void {
+  buildConfigAnacondaIsoInstallerModules.enable = buildConfigAnacondaIsoInstallerModules.enable.filter(
+    (_, i) => i !== index,
+  );
+}
+
+function deleteDisabledAnacondaInstallerModule(index: number): void {
+  buildConfigAnacondaIsoInstallerModules.disable = buildConfigAnacondaIsoInstallerModules.disable.filter(
+    (_, i) => i !== index,
+  );
 }
 
 // Remove any empty strings in the object before passing it in to the backend
@@ -777,7 +809,7 @@ $: if (availableArchitectures) {
               <!-- svelte-ignore a11y-no-static-element-interactions -->
               <span
                 class="font-semibold mb-2 block cursor-pointer"
-                aria-label="build-config-options"
+                aria-label="interactive-build-config-options"
                 on:click={toggleBuildConfig}
                 ><Fa icon={showBuildConfig ? faCaretDown : faCaretRight} class="inline-block mr-1" />Interactive build
                 config
@@ -881,6 +913,56 @@ $: if (availableArchitectures) {
                     id="buildConfigKernelArguments"
                     placeholder="Kernel arguments (ex. quiet)"
                     class="w-full" />
+
+                  <!-- The below section is related to anaconda-iso, only show if buildType has 'anaconda-iso' in it -->
+                  <div>
+                    <span class="block mt-6" aria-label="anaconda-iso-installer-module-title"
+                      >Anaconda ISO installer modules</span>
+                  </div>
+                  <div class="grid grid-cols-2 gap-4 mt-2">
+                    <div>
+                      <span class="block">Enable</span>
+                      {#each buildConfigAnacondaIsoInstallerModules.enable as _, index}
+                        <div class="flex flex-row justify-center items-center w-full py-1">
+                          <Input
+                            placeholder="Module name"
+                            class="mr-2"
+                            bind:value={buildConfigAnacondaIsoInstallerModules.enable[index]} />
+                          <Button
+                            type="link"
+                            hidden={index === buildConfigAnacondaIsoInstallerModules.enable.length - 1}
+                            on:click={(): void => deleteEnabledAnacondaInstallerModule(index)}
+                            icon={faMinusCircle} />
+                          <Button
+                            type="link"
+                            hidden={index < buildConfigAnacondaIsoInstallerModules.enable.length - 1}
+                            on:click={addEnabledAnacondaInstallerModule}
+                            icon={faPlusCircle} />
+                        </div>
+                      {/each}
+                    </div>
+                    <div>
+                      <span class="block">Disable</span>
+                      {#each buildConfigAnacondaIsoInstallerModules.disable as _, index}
+                        <div class="flex flex-row justify-center items-center w-full py-1">
+                          <Input
+                            placeholder="Module name"
+                            class="mr-2"
+                            bind:value={buildConfigAnacondaIsoInstallerModules.disable[index]} />
+                          <Button
+                            type="link"
+                            hidden={index === buildConfigAnacondaIsoInstallerModules.disable.length - 1}
+                            on:click={(): void => deleteDisabledAnacondaInstallerModule(index)}
+                            icon={faMinusCircle} />
+                          <Button
+                            type="link"
+                            hidden={index < buildConfigAnacondaIsoInstallerModules.disable.length - 1}
+                            on:click={addDisabledAnacondaInstallerModule}
+                            icon={faPlusCircle} />
+                        </div>
+                      {/each}
+                    </div>
+                  </div>
                 </div>
               {/if}
             </div>
@@ -1014,4 +1096,5 @@ $: if (availableArchitectures) {
         {/if}
       </div>
     {/if}
-  </div></FormPage>
+  </div>
+</FormPage>

--- a/packages/shared/src/models/bootc.ts
+++ b/packages/shared/src/models/bootc.ts
@@ -26,6 +26,7 @@ export interface BuildConfig {
   user?: BuildConfigUser[];
   filesystem?: BuildConfigFilesystem[];
   kernel?: BuildConfigKernel;
+  anacondaIsoInstallerModules?: BuildConfigAnacondaIsoInstallerModules;
   // In the future:
   // * Add installer.kickstart https://github.com/osbuild/bootc-image-builder?tab=readme-ov-file#anaconda-iso-installer-options-installer-mapping
   // * Add anaconda iso modules https://github.com/osbuild/bootc-image-builder?tab=readme-ov-file#anaconda-iso-installer-modules
@@ -41,6 +42,11 @@ export interface BuildConfigUser {
 export interface BuildConfigFilesystem {
   mountpoint: string;
   minsize: string;
+}
+
+export interface BuildConfigAnacondaIsoInstallerModules {
+  enable: string[];
+  disable: string[];
 }
 
 export interface BuildConfigKernel {


### PR DESCRIPTION
feat: add anaconda iso module enable / disable

### What does this PR do?

* Adds the ability to disable or enable any anaconda iso modules
* Added to build page with ability to choose enable/disable and
  add/remove as many as you want.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

https://github.com/user-attachments/assets/e20ae912-3c81-49ed-8095-9ff6f69aa477

![Screenshot 2025-02-10 at 12 19 38 PM](https://github.com/user-attachments/assets/d95dc3b3-d1dd-4a69-8489-776259c275f0)




### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/podman-desktop/extension-bootc/issues/1028

### How to test this PR?

<!-- Please explain steps to reproduce -->

1. Add a few entries from within the build page.
2. Check your `config.json` after creation (it's in the same folder as
   your output folder).
3. Confirm modules have been put in there.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
