### PR TITLE
chore: fix backend code coverage report

### DIFF
--- a/packages/backend/vitest.config.js
+++ b/packages/backend/vitest.config.js
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 Red Hat, Inc.
+ * Copyright (C) 2024-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,9 +27,10 @@ const config = {
     coverage: {
       provider: 'v8',
       reporter: ['lcov', 'text'],
+      extension: '.ts',
     },
-},
-resolve: {
+  },
+  resolve: {
     alias: {
       '@podman-desktop/api': path.resolve(__dirname, '__mocks__/@podman-desktop/api.js'),
       '/@/': join(PACKAGE_ROOT, 'src') + '/',


### PR DESCRIPTION
### What does this PR do?

Code coverage reports were including lots of files that aren't in the package.

As usual, my first step was to steal from the AI Lab extension! :) The fix is in vitest.config, but I also found some minor differences/formatting in vite.config that I thought were worth picking up and aligning to.

### Screenshot / video of UI

Coverage report down from multiple pages to:
```
 % Coverage report from v8
----------------------|---------|----------|---------|---------|-----------------------------------------------------------------------------------
File                  | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s                                                                 
----------------------|---------|----------|---------|---------|-----------------------------------------------------------------------------------
All files             |    47.1 |    76.96 |   47.16 |    47.1 |                                                                                   
 src                  |   46.34 |    76.57 |   46.07 |   46.34 |                                                                                   
  api-impl.ts         |   22.26 |      100 |   11.76 |   22.26 | ...93-294,297-298,301-302,305-306,309-310,313-314,318-323,329-335,339-340,347-351 
  build-disk-image.ts |   39.79 |     92.3 |      60 |   39.79 | 39,47-50,60-372,384-386,520-539,546-552                                           
  constants.ts        |     100 |      100 |     100 |     100 |                                                                                   
  container-utils.ts  |   76.15 |    70.17 |    90.9 |   76.15 | ...45-146,157-159,188-189,246-248,257-258,262-264,284-286,303-308,323-325,335-356 
  extension.ts        |   73.83 |    77.77 |     100 |   73.83 | 68-78,84-94,114,121-122,141-143                                                   
  history.ts          |   44.56 |    66.66 |      60 |   44.56 | 31-32,38-39,46-53,65-66,71-73,81-82,93-107,112-137                                
  machine-utils.ts    |   74.82 |     62.5 |   68.75 |   74.82 | ...41,48-52,80-81,110-112,125-127,132-134,157-158,179-180,183-184,187-188,191-201 
  vm-manager.ts       |   24.38 |     92.3 |   26.66 |   24.38 | ...89-106,109-135,141-155,158-180,185-201,204-226,231-247,250-270,297-301,305-311 
 src/history          |      92 |      100 |      75 |      92 |                                                                                   
  historyNotifier.ts  |      92 |      100 |      75 |      92 | 47-48                                                                             
----------------------|---------|----------|---------|---------|-----------------------------------------------------------------------------------
```

### What issues does this PR fix or reference?

Fixes #1321.

### How to test this PR?

`pnpm test:backend`