### PR TITLE
feat: add kickstart file to interactive installer

### DIFF
--- a/packages/backend/src/api-impl.ts
+++ b/packages/backend/src/api-impl.ts
@@ -168,6 +168,24 @@ export class BootcApiImpl implements BootcApi {
     return '';
   }
 
+  // Anaconda kickstart file ends in .ks extension
+  async selectAnacondaKickstartFile(): Promise<string> {
+    const path = await podmanDesktopApi.window.showOpenDialog({
+      title: 'Select Anaconda kickstart file',
+      selectors: ['openFile'],
+      filters: [
+        {
+          name: '*',
+          extensions: ['ks'],
+        },
+      ],
+    });
+    if (path && path.length > 0) {
+      return path[0].fsPath;
+    }
+    return '';
+  }
+
   async listAllImages(): Promise<ImageInfo[]> {
     let images: ImageInfo[] = [];
     try {

--- a/packages/frontend/src/Build.spec.ts
+++ b/packages/frontend/src/Build.spec.ts
@@ -871,3 +871,29 @@ test('expect anaconda modules ISO section to be shown', async () => {
   const anacondaModules = screen.getByLabelText('anaconda-iso-installer-module-title');
   expect(anacondaModules).toBeDefined();
 });
+
+test('expect anaconda kickstart file section to be shown', async () => {
+  vi.mocked(bootcClient.inspectImage).mockResolvedValue(mockImageInspect);
+  vi.mocked(bootcClient.listHistoryInfo).mockResolvedValue(mockHistoryInfo);
+  vi.mocked(bootcClient.listBootcImages).mockResolvedValue(mockBootcImages);
+  vi.mocked(bootcClient.buildExists).mockResolvedValue(false);
+  vi.mocked(bootcClient.checkPrereqs).mockResolvedValue(undefined);
+  render(Build);
+
+  // Wait until children length is 2 meaning it's fully rendered / propagated the changes
+  await vi.waitFor(() => {
+    if (screen.getByLabelText('image-select')?.children.length !== 2) {
+      throw new Error();
+    }
+  });
+
+  // Find the "build-config-options" aria-label span and click it
+  const buildConfigOptions = screen.getByLabelText('interactive-build-config-options');
+  expect(buildConfigOptions).toBeDefined();
+  await userEvent.click(buildConfigOptions);
+
+  // Expect anaconda kickstart file to be shown
+  // Wait for Anaconda kickstart file to be shown (span)
+  const anacondaKickstart = screen.getByLabelText('anaconda-iso-installer-kickstart-file-title');
+  expect(anacondaKickstart).toBeDefined();
+});

--- a/packages/frontend/src/Build.svelte
+++ b/packages/frontend/src/Build.svelte
@@ -44,6 +44,7 @@ let availableArchitectures: string[] = [];
 // Build options
 let buildFolder: string;
 let buildConfigFile: string;
+let buildConfigAnacondaKickstartFilePath: string;
 let buildChown: string;
 let buildType: BuildType[] = [];
 let buildArch: string | undefined;
@@ -267,6 +268,7 @@ async function buildBootcImage(): Promise<void> {
     kernel: {
       append: buildConfigKernelArguments,
     },
+    anacondaIsoInstallerKickstartFilePath: buildConfigAnacondaKickstartFilePath,
     anacondaIsoInstallerModules: convertedBuildConfigAnacondaIsoInstallerModules,
   }) as BuildConfig;
 
@@ -358,6 +360,10 @@ async function getPath(): Promise<void> {
 
 async function getBuildConfigFile(): Promise<void> {
   buildConfigFile = await bootcClient.selectBuildConfigFile();
+}
+
+async function getAnacondaKickstartFile(): Promise<void> {
+  buildConfigAnacondaKickstartFilePath = await bootcClient.selectAnacondaKickstartFile();
 }
 
 function cleanup(): void {
@@ -924,7 +930,24 @@ $: if (availableArchitectures) {
                     class="w-full" />
 
                   <div>
-                    <span class="block mt-6" aria-label="anaconda-iso-installer-module-title"
+                    <span class="block mt-4" aria-label="anaconda-iso-installer-kickstart-file-title"
+                      >Anaconda ISO kickstart file</span>
+                  </div>
+                  <div class="mb-2">
+                    <div class="flex flex-row space-x-3">
+                      <Input
+                        name="kickstart"
+                        id="kickstart"
+                        bind:value={buildConfigAnacondaKickstartFilePath}
+                        placeholder="Kickstart file (*.ks)"
+                        class="w-full"
+                        aria-label="kickstart-select" />
+                      <Button on:click={getAnacondaKickstartFile}>Browse...</Button>
+                    </div>
+                  </div>
+
+                  <div>
+                    <span class="block mt-4" aria-label="anaconda-iso-installer-module-title"
                       >Anaconda ISO installer modules</span>
                   </div>
                   <div class="grid grid-cols-2 gap-4 mt-2">

--- a/packages/shared/src/BootcAPI.ts
+++ b/packages/shared/src/BootcAPI.ts
@@ -33,6 +33,7 @@ export abstract class BootcApi {
   abstract deleteBuilds(buildIds: string[]): Promise<void>;
   abstract selectOutputFolder(): Promise<string>;
   abstract selectBuildConfigFile(): Promise<string>;
+  abstract selectAnacondaKickstartFile(): Promise<string>;
   abstract listBootcImages(): Promise<ImageInfo[]>;
   abstract listAllImages(): Promise<ImageInfo[]>;
   abstract listHistoryInfo(): Promise<BootcBuildInfo[]>;

--- a/packages/shared/src/models/bootc.ts
+++ b/packages/shared/src/models/bootc.ts
@@ -26,6 +26,7 @@ export interface BuildConfig {
   user?: BuildConfigUser[];
   filesystem?: BuildConfigFilesystem[];
   kernel?: BuildConfigKernel;
+  anacondaIsoInstallerKickstartFilePath?: string;
   anacondaIsoInstallerModules?: BuildConfigAnacondaIsoInstallerModules;
   // In the future:
   // * Add installer.kickstart https://github.com/osbuild/bootc-image-builder?tab=readme-ov-file#anaconda-iso-installer-options-installer-mapping


### PR DESCRIPTION
feat: add kickstart file to interactive installer

### What does this PR do?

Adds the ability to provide a kickstart file to the interactive
installer.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

![Screenshot 2025-02-14 at 9 17 34 AM](https://github.com/user-attachments/assets/9315c598-0461-41cf-8f03-72beb83c9bfc)

![Screenshot 2025-02-14 at 9 18 45 AM](https://github.com/user-attachments/assets/51ea94a0-9b4f-4f20-850d-7f560270ec8a)



### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/podman-desktop/extension-bootc/issues/1027

### How to test this PR?

<!-- Please explain steps to reproduce -->

1. Save an example kickstart file:

```sh
  # Kickstart file for CentOS 7
  #platform=x86, AMD64, or Intel EM64T
  # System authorization information
  auth --enableshadow --passalgo=sha512
  # Use CDROM installation media
  cdrom
  # Use graphical install
  graphical
  # Run the Setup Agent on first boot
  firstboot --enable
  # Keyboard layouts
  keyboard --vckeymap=us --xlayouts='us'
  # System language
  lang en_US
```

2. Use interactive installer on the build page and select the file.

3. Confirm you are able to build it / it passes validation with iso.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
