### PR TITLE
chore: remove a href from build page

### DIFF
--- a/packages/frontend/src/Build.spec.ts
+++ b/packages/frontend/src/Build.spec.ts
@@ -111,6 +111,7 @@ vi.mock('./api/client', async () => {
       buildImage: vi.fn(),
       isMac: vi.fn().mockImplementation(() => mockIsMac),
       isWindows: vi.fn().mockImplementation(() => mockIsWindows),
+      openLink: vi.fn(),
     },
     rpcBrowser: {
       subscribe: (): Subscriber => {
@@ -418,6 +419,9 @@ test('Do not show an image if it has no repotags and has isManifest as false', a
   vi.mocked(bootcClient.listBootcImages).mockResolvedValue(mockedImages);
   vi.mocked(bootcClient.buildExists).mockResolvedValue(false);
   vi.mocked(bootcClient.checkPrereqs).mockResolvedValue(undefined);
+
+  const linkSpy = vi.spyOn(bootcClient, 'openLink');
+
   render(Build);
 
   // Wait until children length is 1
@@ -435,6 +439,13 @@ test('Do not show an image if it has no repotags and has isManifest as false', a
   // Find the <p> that CONTAINS "No bootable container compatible images found."
   const noImages = screen.getByText(/No bootable container compatible images found./);
   expect(noImages).toBeDefined();
+
+  const link = screen.getByText('README');
+  expect(link).toBeDefined();
+
+  await userEvent.click(link);
+
+  expect(linkSpy).toBeCalledWith('https://github.com/containers/podman-desktop-extension-bootc');
 });
 
 test('If inspectImage fails, do not select any architecture / make them available', async () => {

--- a/packages/frontend/src/Build.spec.ts
+++ b/packages/frontend/src/Build.spec.ts
@@ -420,8 +420,6 @@ test('Do not show an image if it has no repotags and has isManifest as false', a
   vi.mocked(bootcClient.buildExists).mockResolvedValue(false);
   vi.mocked(bootcClient.checkPrereqs).mockResolvedValue(undefined);
 
-  const linkSpy = vi.spyOn(bootcClient, 'openLink');
-
   render(Build);
 
   // Wait until children length is 1
@@ -445,7 +443,9 @@ test('Do not show an image if it has no repotags and has isManifest as false', a
 
   await userEvent.click(link);
 
-  expect(linkSpy).toBeCalledWith('https://github.com/containers/podman-desktop-extension-bootc');
+  expect(vi.mocked(bootcClient.openLink)).toBeCalledWith(
+    'https://github.com/containers/podman-desktop-extension-bootc',
+  );
 });
 
 test('If inspectImage fails, do not select any architecture / make them available', async () => {

--- a/packages/frontend/src/Build.svelte
+++ b/packages/frontend/src/Build.svelte
@@ -614,9 +614,8 @@ $: if (availableArchitectures) {
             </div>
             {#if bootcAvailableImages.length === 0}
               <p class="text-[var(--pd-state-warning)] pt-1">
-                No bootable container compatible images found. Learn to create one on our <a
-                  class="text-purple-400 hover:bg-white hover:bg-opacity-10 transition-all rounded-[4px] p-0.5 no-underline cursor-pointer"
-                  href="https://github.com/containers/podman-desktop-extension-bootc">README</a
+                No bootable container compatible images found. Learn to create one on our <Link
+                  externalRef="https://github.com/containers/podman-desktop-extension-bootc">README</Link
                 >.
               </p>
             {/if}


### PR DESCRIPTION
### What does this PR do?

The build page still had a link using hard-coded color values, just convert to a Link like all the others.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Part of #975.

### How to test this PR?

When you have no bootc images the link should still appear and work.