### PR TITLE
chore: replace spy with vi.mocked

### DIFF
--- a/packages/backend/src/build-disk-image.spec.ts
+++ b/packages/backend/src/build-disk-image.spec.ts
@@ -41,6 +41,8 @@ const config: Configuration = {
   update: vi.fn(),
 };
 
+vi.mock('node:fs');
+
 vi.mock('@podman-desktop/api', async () => {
   return {
     env: {
@@ -250,7 +252,6 @@ test('check build exists', async () => {
 
   // mock two existing builds on disk: qcow2 and vmdk
   const existsList: string[] = [resolve(folder, 'qcow2/disk.qcow2'), resolve(folder, 'vmdk/disk.vmdk')];
-  vi.mock('node:fs');
   vi.spyOn(fs, 'existsSync').mockImplementation(f => {
     return existsList.includes(f.toString());
   });
@@ -540,8 +541,6 @@ test('test building with a buildConfig JSON file that a temporary file for build
     folder: '/foo/bar/qemutest4',
     buildConfig: buildConfig,
   } as BootcBuildInfo;
-
-  vi.mock('node:fs');
 
   const options = createBuilderImageOptions(name, build);
 

--- a/packages/backend/src/build-disk-image.spec.ts
+++ b/packages/backend/src/build-disk-image.spec.ts
@@ -541,9 +541,7 @@ test('test building with a buildConfig JSON file that a temporary file for build
     buildConfig: buildConfig,
   } as BootcBuildInfo;
 
-  // Spy on fs.writeFileSync to make sure it is called
   vi.mock('node:fs');
-  vi.spyOn(fs, 'writeFileSync');
 
   const options = createBuilderImageOptions(name, build);
 

--- a/packages/frontend/src/Build.spec.ts
+++ b/packages/frontend/src/Build.spec.ts
@@ -479,9 +479,6 @@ test('If inspectImage fails, do not select any architecture / make them availabl
 });
 
 test('Show the image if isManifest: true and Labels is empty', async () => {
-  // spy on inspectManifest
-  const spyOnInspectManifest = vi.spyOn(bootcClient, 'inspectManifest');
-
   const mockedImages: ImageInfo[] = [
     {
       Id: 'testmanifest1',
@@ -548,7 +545,7 @@ test('Show the image if isManifest: true and Labels is empty', async () => {
   render(Build, { imageName: 'testmanifest1', imageTag: 'latest' });
 
   await vi.waitFor(() => {
-    expect(spyOnInspectManifest).toHaveBeenCalled();
+    expect(vi.mocked(bootcClient.inspectManifest)).toHaveBeenCalled();
   });
 
   // Wait to render
@@ -571,9 +568,6 @@ test('Show the image if isManifest: true and Labels is empty', async () => {
 });
 
 test('have amd64 and arm64 NOT disabled if inspectManifest contains both architectures / child images', async () => {
-  // spy on inspectManifest
-  const spyOnInspectManifest = vi.spyOn(bootcClient, 'inspectManifest');
-
   const mockedImages: ImageInfo[] = [
     {
       Id: 'testmanifest1',
@@ -669,7 +663,7 @@ test('have amd64 and arm64 NOT disabled if inspectManifest contains both archite
   render(Build, { imageName: 'testmanifest1', imageTag: 'latest' });
 
   await vi.waitFor(() => {
-    expect(spyOnInspectManifest).toHaveBeenCalled();
+    expect(vi.mocked(bootcClient.inspectManifest)).toHaveBeenCalled();
   });
 
   // Wait to render

--- a/packages/frontend/src/Build.spec.ts
+++ b/packages/frontend/src/Build.spec.ts
@@ -443,9 +443,7 @@ test('Do not show an image if it has no repotags and has isManifest as false', a
 
   await userEvent.click(link);
 
-  expect(vi.mocked(bootcClient.openLink)).toBeCalledWith(
-    'https://github.com/containers/podman-desktop-extension-bootc',
-  );
+  expect(bootcClient.openLink).toBeCalledWith('https://github.com/containers/podman-desktop-extension-bootc');
 });
 
 test('If inspectImage fails, do not select any architecture / make them available', async () => {
@@ -545,7 +543,7 @@ test('Show the image if isManifest: true and Labels is empty', async () => {
   render(Build, { imageName: 'testmanifest1', imageTag: 'latest' });
 
   await vi.waitFor(() => {
-    expect(vi.mocked(bootcClient.inspectManifest)).toHaveBeenCalled();
+    expect(bootcClient.inspectManifest).toHaveBeenCalled();
   });
 
   // Wait to render
@@ -663,7 +661,7 @@ test('have amd64 and arm64 NOT disabled if inspectManifest contains both archite
   render(Build, { imageName: 'testmanifest1', imageTag: 'latest' });
 
   await vi.waitFor(() => {
-    expect(vi.mocked(bootcClient.inspectManifest)).toHaveBeenCalled();
+    expect(bootcClient.inspectManifest).toHaveBeenCalled();
   });
 
   // Wait to render

--- a/packages/frontend/src/lib/disk-image/DiskImageActions.spec.ts
+++ b/packages/frontend/src/lib/disk-image/DiskImageActions.spec.ts
@@ -69,7 +69,7 @@ test('Test clicking on delete button', async () => {
   const deleteButton = screen.getAllByRole('button', { name: 'Delete Build' })[0];
   deleteButton.click();
 
-  expect(vi.mocked(bootcClient.deleteBuilds)).toHaveBeenCalledWith(['name1']);
+  expect(bootcClient.deleteBuilds).toHaveBeenCalledWith(['name1']);
 });
 
 test('Test clicking on logs button', async () => {

--- a/packages/frontend/src/lib/disk-image/DiskImageActions.spec.ts
+++ b/packages/frontend/src/lib/disk-image/DiskImageActions.spec.ts
@@ -65,15 +65,11 @@ test('Test clicking on delete button', async () => {
   vi.mocked(bootcClient.isWindows).mockResolvedValue(false);
   render(DiskImageActions, { object: mockHistoryInfo });
 
-  // spy on deleteBuild function
-  const spyOnDelete = vi.spyOn(bootcClient, 'deleteBuilds');
-
   // Click on delete button
   const deleteButton = screen.getAllByRole('button', { name: 'Delete Build' })[0];
   deleteButton.click();
 
-  expect(spyOnDelete).toHaveBeenCalled();
-  expect(spyOnDelete).toHaveBeenCalledWith(['name1']);
+  expect(vi.mocked(bootcClient.deleteBuilds)).toHaveBeenCalledWith(['name1']);
 });
 
 test('Test clicking on logs button', async () => {

--- a/packages/frontend/src/lib/disk-image/DiskImagesList.spec.ts
+++ b/packages/frontend/src/lib/disk-image/DiskImagesList.spec.ts
@@ -105,15 +105,11 @@ test('Test clicking on delete button', async () => {
     }
   });
 
-  // spy on deleteBuild function
-  const spyOnDelete = vi.spyOn(bootcClient, 'deleteBuilds');
-
   // Click on delete button
   const deleteButton = screen.getAllByRole('button', { name: 'Delete Build' })[0];
   deleteButton.click();
 
-  expect(spyOnDelete).toHaveBeenCalled();
-  expect(spyOnDelete).toHaveBeenCalledWith(['name1']);
+  expect(vi.mocked(bootcClient.deleteBuilds)).toHaveBeenCalledWith(['name1']);
 });
 
 test('Test clicking on build button', async () => {
@@ -126,12 +122,9 @@ test('Test clicking on build button', async () => {
     }
   });
 
-  // spy on telemetryLogUsage function
-  const spyOnLogUsage = vi.spyOn(bootcClient, 'telemetryLogUsage');
-
   // Click on build button
   const buildButton = screen.getAllByRole('button', { name: 'Build' })[0];
   buildButton.click();
 
-  expect(spyOnLogUsage).toHaveBeenCalled();
+  expect(vi.mocked(bootcClient.telemetryLogUsage)).toHaveBeenCalled();
 });

--- a/packages/frontend/src/lib/disk-image/DiskImagesList.spec.ts
+++ b/packages/frontend/src/lib/disk-image/DiskImagesList.spec.ts
@@ -109,7 +109,7 @@ test('Test clicking on delete button', async () => {
   const deleteButton = screen.getAllByRole('button', { name: 'Delete Build' })[0];
   deleteButton.click();
 
-  expect(vi.mocked(bootcClient.deleteBuilds)).toHaveBeenCalledWith(['name1']);
+  expect(bootcClient.deleteBuilds).toHaveBeenCalledWith(['name1']);
 });
 
 test('Test clicking on build button', async () => {
@@ -126,5 +126,5 @@ test('Test clicking on build button', async () => {
   const buildButton = screen.getAllByRole('button', { name: 'Build' })[0];
   buildButton.click();
 
-  expect(vi.mocked(bootcClient.telemetryLogUsage)).toHaveBeenCalled();
+  expect(bootcClient.telemetryLogUsage).toHaveBeenCalled();
 });

--- a/packages/frontend/src/stores/rpcReadable.spec.ts
+++ b/packages/frontend/src/stores/rpcReadable.spec.ts
@@ -55,7 +55,7 @@ test('check updater is called once at subscription', async () => {
     return Promise.resolve(['']);
   });
   rpcWritable.subscribe(_ => {});
-  expect(vi.mocked(bootcClient.listHistoryInfo)).toHaveBeenCalledTimes(1);
+  expect(bootcClient.listHistoryInfo).toHaveBeenCalledTimes(1);
 });
 
 test('check updater is called twice if there is one event fired', async () => {
@@ -67,7 +67,7 @@ test('check updater is called twice if there is one event fired', async () => {
   rpcBrowser.invoke('event').catch((e: unknown) => console.error('error sending event', e));
   // wait for the timeout in the debouncer
   await new Promise(resolve => setTimeout(resolve, 600));
-  expect(vi.mocked(bootcClient.listHistoryInfo)).toHaveBeenCalledTimes(2);
+  expect(bootcClient.listHistoryInfo).toHaveBeenCalledTimes(2);
 });
 
 test('check updater is called only twice because of the debouncer if there is more than one event in a row', async () => {
@@ -82,5 +82,5 @@ test('check updater is called only twice because of the debouncer if there is mo
   rpcBrowser.invoke('event2').catch((e: unknown) => console.error('error sending event', e));
   // wait for the timeout in the debouncer
   await new Promise(resolve => setTimeout(resolve, 600));
-  expect(vi.mocked(bootcClient.listHistoryInfo)).toHaveBeenCalledTimes(2);
+  expect(bootcClient.listHistoryInfo).toHaveBeenCalledTimes(2);
 });

--- a/packages/frontend/src/stores/rpcReadable.spec.ts
+++ b/packages/frontend/src/stores/rpcReadable.spec.ts
@@ -50,17 +50,15 @@ beforeEach(() => {
 });
 
 test('check updater is called once at subscription', async () => {
-  const spyOnListHistoryInfo = vi.spyOn(bootcClient, 'listHistoryInfo');
   const rpcWritable = RPCReadable<string[]>([], [], () => {
     bootcClient.listHistoryInfo().catch((e: unknown) => console.error('error listing history', e));
     return Promise.resolve(['']);
   });
   rpcWritable.subscribe(_ => {});
-  expect(spyOnListHistoryInfo).toHaveBeenCalledTimes(1);
+  expect(vi.mocked(bootcClient.listHistoryInfo)).toHaveBeenCalledTimes(1);
 });
 
 test('check updater is called twice if there is one event fired', async () => {
-  const spyOnListHistoryInfo = vi.spyOn(bootcClient, 'listHistoryInfo');
   const rpcWritable = RPCReadable<string[]>([], ['event'], () => {
     bootcClient.listHistoryInfo().catch((e: unknown) => console.error('error listing history', e));
     return Promise.resolve(['']);
@@ -69,11 +67,10 @@ test('check updater is called twice if there is one event fired', async () => {
   rpcBrowser.invoke('event').catch((e: unknown) => console.error('error sending event', e));
   // wait for the timeout in the debouncer
   await new Promise(resolve => setTimeout(resolve, 600));
-  expect(spyOnListHistoryInfo).toHaveBeenCalledTimes(2);
+  expect(vi.mocked(bootcClient.listHistoryInfo)).toHaveBeenCalledTimes(2);
 });
 
 test('check updater is called only twice because of the debouncer if there is more than one event in a row', async () => {
-  const spyOnListHistoryInfo = vi.spyOn(bootcClient, 'listHistoryInfo');
   const rpcWritable = RPCReadable<string[]>([], ['event2'], () => {
     bootcClient.listHistoryInfo().catch((e: unknown) => console.error('error listing history', e));
     return Promise.resolve(['']);
@@ -85,5 +82,5 @@ test('check updater is called only twice because of the debouncer if there is mo
   rpcBrowser.invoke('event2').catch((e: unknown) => console.error('error sending event', e));
   // wait for the timeout in the debouncer
   await new Promise(resolve => setTimeout(resolve, 600));
-  expect(spyOnListHistoryInfo).toHaveBeenCalledTimes(2);
+  expect(vi.mocked(bootcClient.listHistoryInfo)).toHaveBeenCalledTimes(2);
 });


### PR DESCRIPTION
### What does this PR do?

From a comment on #1339, we use a spy in several places where we should now be using vi.mocked(). This just cleans up the low hanging fruit.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Part of #975.

### How to test this PR?

Code review, PR checks still green.