### PR TITLE
fix: correctly kick off build in background

### DIFF
--- a/packages/backend/src/build-disk-image.ts
+++ b/packages/backend/src/build-disk-image.ts
@@ -112,9 +112,9 @@ export async function buildDiskImage(build: BootcBuildInfo, history: History, ov
   const telemetryData: Record<string, unknown> = {};
   telemetryData.build = build;
 
-  // "Returning" withProgress allows PD to handle the task in the background with building.
+  // Kick off task using withProgress to build in the background
   let errorMessage: string;
-  return extensionApi.window
+  extensionApi.window
     .withProgress(
       { location: extensionApi.ProgressLocation.TASK_WIDGET, title: `Building disk image ${build.image}` },
       async progress => {
@@ -342,7 +342,8 @@ export async function buildDiskImage(build: BootcBuildInfo, history: History, ov
           'OK',
         );
       }
-    });
+    })
+    .catch((e: unknown) => console.error('error building disk image', e));
 }
 
 async function logContainer(


### PR DESCRIPTION
### What does this PR do?

Either during increasing our linting rules and properly handling promises, or updating the message proxy, the behaviour of returning a promise from buildDiskImage() changed. Instead of returning the window.withProgress promise immediately, it now waits until the task/promise is complete before returning. As a result, the build always 'times out' and you receive an error in the UI.

The correct behaviour should be returning immediately after starting the background task. This just adds a catch block so that we can remove the return and not await.

I'll be honest, I have no idea how to correctly test for this behaviour. :)

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes #1302.

### How to test this PR?

See #1302. Start a build and confirm you're redirected to the build logs instead of receiving a timeout error.