### PR TITLE
fix: refresh log timeout not triggering

### DIFF
--- a/packages/frontend/src/lib/disk-image/DiskImageDetailsBuild.spec.ts
+++ b/packages/frontend/src/lib/disk-image/DiskImageDetailsBuild.spec.ts
@@ -98,7 +98,7 @@ test('Refreshes logs correctly', async () => {
       expect(bootcClient.loadLogsFromFolder).toHaveBeenCalledTimes(2);
     },
     {
-      timeout: 3500,
+      timeout: 3_500,
       interval: 250,
     },
   );

--- a/packages/frontend/src/lib/disk-image/DiskImageDetailsBuild.svelte
+++ b/packages/frontend/src/lib/disk-image/DiskImageDetailsBuild.svelte
@@ -18,7 +18,7 @@ let { folder }: Props = $props();
 let logsXtermDiv = $state<HTMLDivElement>();
 let noLogs = $state(true);
 let previousLogs = $state('');
-const refreshInterval = $state(2000);
+const refreshInterval = 2000;
 
 // Terminal resize
 let resizeObserver = $state<ResizeObserver>();
@@ -88,7 +88,7 @@ onMount(async () => {
   // not possible through RPC calls (yet).
   await fetchFolderLogs();
   logInterval = setInterval(() => {
-    fetchFolderLogs;
+    fetchFolderLogs().catch((e: unknown) => console.error('error fetching logs', e));
   }, refreshInterval);
 
   // Resize the terminal each time we change the div size

--- a/packages/frontend/src/lib/disk-image/DiskImageDetailsBuild.svelte
+++ b/packages/frontend/src/lib/disk-image/DiskImageDetailsBuild.svelte
@@ -18,7 +18,7 @@ let { folder }: Props = $props();
 let logsXtermDiv = $state<HTMLDivElement>();
 let noLogs = $state(true);
 let previousLogs = $state('');
-const refreshInterval = 2000;
+const refreshInterval = 2_000;
 
 // Terminal resize
 let resizeObserver = $state<ResizeObserver>();


### PR DESCRIPTION
### What does this PR do?

#1286 caused a regression where fetchFolderLogs is no longer called every 2s. Added () and a catch so that it's called correctly. Also, refreshInterval is a constant so shouldn't be part of the state.

Tempted to make the interval a parameter to reduce test time, but started by just adding a test that waits to confirm the timeout starts triggering with 3.5s.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes #1303.

### How to test this PR?

Start a build, open logs, and confirm that the output keeps updating.