### PR TITLE
chore: allow dependencies to be built with pnpm v10

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,8 @@
   "pnpm": {
     "overrides": {
       "vite>esbuild": "^0.25.0"
-    }
+    },
+    "neverBuiltDependencies": []
   },
   "packageManager": "pnpm@9.10.0+sha512.73a29afa36a0d092ece5271de5177ecbf8318d454ecd701343131b8ebc0c1a91c487da46ab77c8e596d6acf1461e3594ced4becedf8921b074fbd8653ed7051c"
 }


### PR DESCRIPTION
### What does this PR do?
Explicitly state the dependencies with build scripts to execute during ie. install lifecycle phase in pnpm v10. This will enable to e2e tests to run.

We have alternatives, I went with the minimal working solution, other options:
```
"onlyBuiltDependencies": ["electron", "@biomejs/biome", "esbuild", "svelte-preprocess"] -> building those that appeared on the warning
OR
"neverBuiltDependencies": [] -> to build any
```
When I run `pnpm approve-builds` locally, it updated pnpm-workspace.yaml file instead of package.json.
### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
https://github.com/podman-desktop/extension-bootc/issues/1447
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?
E2E tests should be passing now.
<!-- Please explain steps to reproduce -->
