### PR TITLE
chore(test): add check for image badge

### DIFF
--- a/tests/playwright/src/bootc-extension.spec.ts
+++ b/tests/playwright/src/bootc-extension.spec.ts
@@ -130,6 +130,9 @@ test.describe('BootC Extension', () => {
           await playExpect
             .poll(async () => await imagesPage.waitForImageExists(imageName, 30_000), { timeout: 0 })
             .toBeTruthy();
+          await playExpect
+            .poll(async () => await imagesPage.checkImageBadge(imageName, 'bootc'), { timeout: 30_000 })
+            .toBeTruthy();
           imageBuildFailed = false;
         });
 


### PR DESCRIPTION
### What does this PR do?
Adds check for bootc image badge to e2e tests.

### What issues does this PR fix or reference?
https://github.com/podman-desktop/extension-bootc/issues/1374
