### PR TITLE
chore: fix pattern for disk image status column

### DIFF
--- a/packages/frontend/src/lib/BootcStatus.svelte
+++ b/packages/frontend/src/lib/BootcStatus.svelte
@@ -1,9 +1,0 @@
-<script lang="ts">
-import BootcStatusIcon from './BootcStatusIcon.svelte';
-import DiskImageIcon from './DiskImageIcon.svelte';
-import type { BootcBuildInfo } from '/@shared/src/models/bootc';
-
-export let object: BootcBuildInfo;
-</script>
-
-<BootcStatusIcon icon={DiskImageIcon} status={object.status} />

--- a/packages/frontend/src/lib/disk-image/DiskImagesList.svelte
+++ b/packages/frontend/src/lib/disk-image/DiskImagesList.svelte
@@ -4,9 +4,9 @@ import type { BootcBuildInfo } from '/@shared/src/models/bootc';
 import { faTrash } from '@fortawesome/free-solid-svg-icons';
 import DiskImageColumnActions from './columns/Actions.svelte';
 import { bootcClient } from '/@/api/client';
-import BootcStatus from '../BootcStatus.svelte';
 import { searchPattern, filtered } from '../../stores/historyInfo';
 import DiskImageIcon from '../DiskImageIcon.svelte';
+import DiskImageColumnStatus from './columns/Status.svelte';
 import DiskImageColumnFolder from './columns/Folder.svelte';
 import DiskImageColumnImage from './columns/Image.svelte';
 import {
@@ -66,7 +66,7 @@ let table = $state<Table>();
 let statusColumn = new TableColumn<BootcBuildInfo>('Status', {
   align: 'center',
   width: '70px',
-  renderer: BootcStatus,
+  renderer: DiskImageColumnStatus,
 });
 
 let imageColumn = new TableColumn<BootcBuildInfo>('Image', {

--- a/packages/frontend/src/lib/disk-image/columns/Status.svelte
+++ b/packages/frontend/src/lib/disk-image/columns/Status.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+import BootcStatusIcon from '../../BootcStatusIcon.svelte';
+import DiskImageIcon from '../../DiskImageIcon.svelte';
+
+import type { Props } from './props';
+
+let { object }: Props = $props();
+</script>
+
+<BootcStatusIcon icon={DiskImageIcon} status={object.status} />


### PR DESCRIPTION
### What does this PR do?

While working on #862 I noticed that the disk image status column isn't in the folder with the other columns, and doesn't follow the same naming or props patterns. This just moves the file into the correct location/ naming/props/svelte 5 as the other disk image columns.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Found while working on #862.

### How to test this PR?

PR checks, compare to other files in /columns.