### PR TITLE
chore: refactor image pull logic and provide image store

### DIFF
--- a/packages/backend/src/api-impl.ts
+++ b/packages/backend/src/api-impl.ts
@@ -286,18 +286,15 @@ export class BootcApiImpl implements BootcApi {
 
   // Pull an image from the registry
   async pullImage(imageName: string, arch?: string): Promise<void> {
-    let success: boolean = false;
-    let error: string = '';
     try {
       await containerUtils.pullImage(await getContainerEngine(), imageName, arch);
-      success = true;
     } catch (err) {
       await podmanDesktopApi.window.showErrorMessage(`Error pulling image: ${err}`);
       console.error('Error pulling image: ', err);
-      error = String(err);
+      throw new Error(`Error pulling image: ${err}`);
     } finally {
-      // Notify the frontend if the pull was successful, and if there was an error.
-      await this.notify(Messages.MSG_IMAGE_PULL_UPDATE, { image: imageName, success, error });
+      // Notify the frontend the images list may have changed
+      await this.notify(Messages.MSG_IMAGE_UPDATE, {});
     }
   }
 

--- a/packages/frontend/src/lib/dashboard/Dashboard.spec.ts
+++ b/packages/frontend/src/lib/dashboard/Dashboard.spec.ts
@@ -51,7 +51,7 @@ vi.mock('../../api/client', async () => {
     bootcClient: {
       listHistoryInfo: vi.fn(),
       listBootcImages: vi.fn(),
-      pullImage: vi.fn(),
+      pullImage: vi.fn().mockResolvedValue(Promise.resolve),
       isMac: vi.fn(),
       isWindows: vi.fn(),
     },

--- a/packages/frontend/src/lib/dashboard/Dashboard.svelte
+++ b/packages/frontend/src/lib/dashboard/Dashboard.svelte
@@ -50,10 +50,10 @@ async function pullExampleImage(): Promise<void> {
     }
   }, 5_000);
 
-  await bootcClient.pullImage(exampleImage);
-
-  pullInProgress = false;
-  displayDisclaimer = false;
+  await bootcClient.pullImage(exampleImage).finally(() => {
+    pullInProgress = false;
+    displayDisclaimer = false;
+  });
 }
 
 // Each time images updates, check if 'quay.io/bootc-extension/httpd' is in RepoTags

--- a/packages/frontend/src/lib/examples/Examples.spec.ts
+++ b/packages/frontend/src/lib/examples/Examples.spec.ts
@@ -89,6 +89,7 @@ const imagesList = [
 test('Test examples render correctly', async () => {
   // Mock the getExamples method
   vi.mocked(bootcClient.getExamples).mockResolvedValue(examplesList);
+  vi.mocked(bootcClient.listBootcImages).mockResolvedValue([]);
 
   // Render the examples component
   render(Examples);

--- a/packages/frontend/src/lib/examples/ExamplesCard.svelte
+++ b/packages/frontend/src/lib/examples/ExamplesCard.svelte
@@ -2,10 +2,7 @@
 import Card from '/@/lib/Card.svelte';
 import ExampleCard from './ExampleCard.svelte';
 import type { Example, Category } from '/@shared/src/models/examples';
-import { onMount } from 'svelte';
-import { bootcClient, rpcBrowser } from '/@/api/client';
-import type { ImageInfo } from '@podman-desktop/api';
-import { Messages } from '/@shared/src/messages/Messages';
+import { imageInfo } from '../../stores/imageInfo';
 
 interface Props {
   category: Category;
@@ -13,41 +10,16 @@ interface Props {
 }
 let { category, examples = $bindable() }: Props = $props();
 
-let bootcAvailableImages = $state<ImageInfo[]>([]);
-
-onMount(async () => {
-  bootcAvailableImages = await bootcClient.listBootcImages();
-  updateExamplesWithPulledImages();
-
-  // Update the available bootc images if we receive a msg image pull update from the UI
-  return rpcBrowser.subscribe(Messages.MSG_IMAGE_PULL_UPDATE, msg => {
-    bootcClient
-      .listBootcImages()
-      .then(images => {
-        bootcAvailableImages = images;
-      })
-      .catch((e: unknown) => console.error('error while updating images', e));
-
-    if (msg.image) {
-      const example = examples.find(example => example.image === msg.image);
-      if (example) {
-        example.state = 'pulled';
-        examples = [...examples];
-      }
-    }
-  });
-});
-
 // Function to update examples based on available images
 function updateExamplesWithPulledImages(): void {
-  if (bootcAvailableImages) {
+  if ($imageInfo) {
     // Set each state to 'unpulled' by default before updating, as this prevents 'flickering'
     // and unsure states when images are being updated
     for (const example of examples) {
       example.state = 'unpulled';
     }
 
-    for (const image of bootcAvailableImages) {
+    for (const image of $imageInfo) {
       // Only do it if there is a RepoTags
       const [imageRepo, imageTag] = image.RepoTags?.[0]?.split(':') ?? [];
       // Find by image name and tag if it's in the list of examples

--- a/packages/frontend/src/stores/imageInfo.ts
+++ b/packages/frontend/src/stores/imageInfo.ts
@@ -15,7 +15,23 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
-import { BootcApi } from '../BootcAPI';
-import { getChannel } from './utils';
 
-export const noTimeoutChannels: string[] = [getChannel(BootcApi, 'launchVM'), getChannel(BootcApi, 'pullImage')];
+import { derived, writable, type Readable } from 'svelte/store';
+import { Messages } from '/@shared/src/messages/Messages';
+import { bootcClient } from '/@/api/client';
+import { RPCReadable } from '/@/stores/rpcReadable';
+import { findMatchInLeaves } from '../lib/upstream/search-util';
+import type { ImageInfo } from '@podman-desktop/api';
+
+export const imageInfo: Readable<ImageInfo[]> = RPCReadable<ImageInfo[]>(
+  [],
+  [Messages.MSG_IMAGE_UPDATE],
+  bootcClient.listBootcImages,
+);
+
+// For searching
+export const searchPattern = writable('');
+
+export const filtered = derived([searchPattern, imageInfo], ([$searchPattern, $imageInfo]) =>
+  $imageInfo.filter(imageInfo => findMatchInLeaves(imageInfo, $searchPattern.toLowerCase())),
+);

--- a/packages/shared/src/messages/Messages.ts
+++ b/packages/shared/src/messages/Messages.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 Red Hat, Inc.
+ * Copyright (C) 2024-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,8 +17,8 @@
  ***********************************************************************/
 
 export enum Messages {
+  MSG_IMAGE_UPDATE = 'image-update',
   MSG_HISTORY_UPDATE = 'history-update',
-  MSG_IMAGE_PULL_UPDATE = 'image-pull-update', // Responsible for any pull updates
   MSG_NAVIGATE_BUILD = 'navigate-build',
   MSG_VM_LAUNCH_ERROR = 'vm-launch-error',
 }


### PR DESCRIPTION
### What does this PR do?

For disk images (historyInfo) we use a store that's updated via an event (MSG_HISTORY_UPDATE). For container images things are a lot more complicated:
- The list of images on the Dashboard and Examples pages was not reactive, just comes from the API on page load.
- pullImage() is async - but the promise would never fail.
- Since bootc images tend to be > 1Gb, pullImage() almost always times out in the RPC browser.
- A MSG_IMAGE_PULL_UPDATE event was fired and the pages would update state accordingly based on the event.
- The dashboard has a disclaimer after 5s - but this would show in 10s or not at all b/c pullImage would time out.

This commit fixes pullImage and replaces the event logic with an image store:
- pullImage() now returns errors if they occur, and is added to the 'no timeout' list so that it works async correctly.
- A generic MSG_IMAGE_UPDATE is fired when the pull is complete.
- A new ImageInfo store provides a reactive object identical to the disk image store.
- Pages are updated to use the store and remove event logic.

I don't particularly want to create another store, but they are not deprecated in Svelte 5 and using a store moves us in the right direction: consistency for both types of images, and pages updated to use a single/shared reactive object.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Required for #862.

### How to test this PR?

Delete existing bootc images if you have then.

Go to the Bootc Dashboard and pull the example image, make sure the button disables, disclaimer appears after 5s, and when the pull is complete the button re-enables, disclaimer disappears, and image count updates.

Go to the Examples page, pull an image and ensure the button disables, and re-enables/updates when complete.

Do not change pages while pulling, you'll hit unrelated issue #1488. :)