### PR TITLE
chore(test): creating e2e tests for examples bootc page

### DIFF
--- a/tests/playwright/src/bootc-extension.spec.ts
+++ b/tests/playwright/src/bootc-extension.spec.ts
@@ -211,7 +211,7 @@ test.describe('BootC Extension', () => {
 
   for (const example of examples) {
     test.describe
-      .serial(`Bootc examples for ${example} bootable image`, () => {
+      .serial(`Bootc examples for bootable image`, () => {
         test(`Pull ${example.appName} bootable image`, async ({ runner }) => {
           test.setTimeout(180_000);
 

--- a/tests/playwright/src/bootc-extension.spec.ts
+++ b/tests/playwright/src/bootc-extension.spec.ts
@@ -32,6 +32,7 @@ import * as path from 'node:path';
 import * as os from 'node:os';
 import { BootcPage } from './model/bootc-page';
 import { fileURLToPath } from 'node:url';
+import { BootcNavigationBar } from './model/bootc-navigationbar';
 
 let page: Page;
 let webview: Page;
@@ -195,6 +196,64 @@ test.describe('BootC Extension', () => {
                   console.log('Expected to pass on Linux, Windows and macOS');
                   playExpect(result).toBeTruthy();
                 }
+              });
+            });
+        }
+      });
+  }
+
+  const examples = [
+    {
+      appName: 'Apache httpd',
+      imageName: 'registry.gitlab.com/fedora/bootc/examples/httpd:latest',
+    },
+  ];
+
+  for (const example of examples) {
+    test.describe
+      .serial(`Bootc examples for ${example} bootable image`, () => {
+        test(`Pull ${example.appName} bootable image`, async ({ runner }) => {
+          test.setTimeout(180_000);
+
+          [page, webview] = await handleWebview(runner);
+          const bootcNavigationBar = new BootcNavigationBar(page, webview);
+          const bootcExamplesPage = await bootcNavigationBar.openBootcExamples();
+          await playExpect(bootcExamplesPage.heading).toBeVisible();
+          await bootcExamplesPage.pullImage(example.appName);
+        });
+
+        const types = ['QCOW2', 'AMI'];
+
+        for (const type of types) {
+          test.describe
+            .serial('Building images ', () => {
+              test(`Building ${example} bootable image type: ${type}`, async ({ runner }) => {
+                test.skip(isLinux);
+                test.setTimeout(1_250_000);
+
+                [page, webview] = await handleWebview(runner);
+                const bootcNavigationBar = new BootcNavigationBar(page, webview);
+                const bootcExamplesPage = await bootcNavigationBar.openBootcExamples();
+                await playExpect(bootcExamplesPage.heading).toBeVisible();
+                await playExpect(bootcExamplesPage.buildImageButtonLocator(example.appName)).toBeEnabled();
+
+                const pathToStore = path.resolve(
+                  __dirname,
+                  '..',
+                  'tests',
+                  'playwright',
+                  'output',
+                  'images',
+                  `${example.appName}-${type}`,
+                );
+
+                const result = await bootcExamplesPage.buildImage(
+                  example.appName,
+                  example.imageName,
+                  pathToStore,
+                  type,
+                );
+                playExpect(result).toBeTruthy();
               });
             });
         }

--- a/tests/playwright/src/bootc-extension.spec.ts
+++ b/tests/playwright/src/bootc-extension.spec.ts
@@ -227,7 +227,7 @@ test.describe('BootC Extension', () => {
         for (const type of types) {
           test.describe
             .serial('Building images ', () => {
-              test(`Building ${example} bootable image type: ${type}`, async ({ runner }) => {
+              test(`Building ${example.appName} bootable image type: ${type}`, async ({ runner }) => {
                 test.skip(isLinux);
                 test.setTimeout(1_250_000);
 

--- a/tests/playwright/src/model/bootc-examples-page.ts
+++ b/tests/playwright/src/model/bootc-examples-page.ts
@@ -25,13 +25,13 @@ export class BootcExamples {
   readonly page: Page;
   readonly webview: Page;
   readonly heading: Locator;
-  readonly fedoraBoootableCotainerImages: Locator;
+  readonly fedoraBootableContainerImages: Locator;
 
   constructor(page: Page, webview: Page) {
     this.page = page;
     this.webview = webview;
     this.heading = webview.getByRole('region', { name: 'Examples', exact: true });
-    this.fedoraBoootableCotainerImages = webview.getByLabel('Fedora Bootable Container Images', { exact: true });
+    this.fedoraBootableContainerImages = webview.getByLabel('Fedora Bootable Container Images', { exact: true });
   }
 
   public async pullImage(name: string, timeout = 120_000): Promise<void> {
@@ -72,7 +72,7 @@ export class BootcExamples {
   }
 
   private bootableImageLocator(name: string): Locator {
-    return this.fedoraBoootableCotainerImages.getByLabel(name, { exact: true });
+    return this.fedoraBootableContainerImages.getByLabel(name, { exact: true });
   }
 
   private bootableImageButtonLocator(name: string, label: string): Locator {

--- a/tests/playwright/src/model/bootc-examples-page.ts
+++ b/tests/playwright/src/model/bootc-examples-page.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 Red Hat, Inc.
+ * Copyright (C) 2024-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,15 +17,65 @@
  ***********************************************************************/
 
 import type { Locator, Page } from '@playwright/test';
+import { expect as playExpect } from '@playwright/test';
+import { BootcPage } from './bootc-page';
+import { ArchitectureType } from '@podman-desktop/tests-playwright';
 
 export class BootcExamples {
   readonly page: Page;
   readonly webview: Page;
   readonly heading: Locator;
+  readonly fedoraBoootableCotainerImages: Locator;
 
   constructor(page: Page, webview: Page) {
     this.page = page;
     this.webview = webview;
     this.heading = webview.getByRole('region', { name: 'Examples', exact: true });
+    this.fedoraBoootableCotainerImages = webview.getByLabel('Fedora Bootable Container Images', { exact: true });
+  }
+
+  public async pullImage(name: string, timeout = 120_000): Promise<void> {
+    const pullImageButton = this.pullImageButtonLocator(name);
+    await playExpect(pullImageButton).toBeEnabled();
+    await pullImageButton.click();
+    await playExpect(pullImageButton).toBeDisabled({ timeout: 10_000 });
+    await playExpect(this.buildImageButtonLocator(name)).toBeEnabled({ timeout: timeout });
+  }
+
+  public async buildImage(
+    name: string,
+    image: string,
+    pathToStore: string,
+    type: string,
+    timeout = 600_000,
+  ): Promise<boolean> {
+    const buildImageButton = this.buildImageButtonLocator(name);
+    await playExpect(buildImageButton).toBeEnabled();
+    await buildImageButton.click();
+    await playExpect(this.heading).not.toBeVisible({ timeout: 10_000 });
+
+    const bootcBuildImagePage = new BootcPage(this.page, this.webview);
+    await playExpect(bootcBuildImagePage.heading).toBeVisible({ timeout: 10_000 });
+    return await bootcBuildImagePage.buildDiskImage(image, pathToStore, type, ArchitectureType.Default, timeout);
+  }
+
+  public pullImageButtonLocator(name: string): Locator {
+    return this.bootableImageButtonLocator(name, 'Pull image');
+  }
+
+  public buildImageButtonLocator(name: string): Locator {
+    return this.bootableImageButtonLocator(name, 'Build image');
+  }
+
+  public moreDetailsButtonLocator(name: string): Locator {
+    return this.bootableImageButtonLocator(name, 'MoreDetails');
+  }
+
+  private bootableImageLocator(name: string): Locator {
+    return this.fedoraBoootableCotainerImages.getByLabel(name, { exact: true });
+  }
+
+  private bootableImageButtonLocator(name: string, label: string): Locator {
+    return this.bootableImageLocator(name).getByLabel(label, { exact: true });
   }
 }

--- a/tests/playwright/src/model/bootc-page.ts
+++ b/tests/playwright/src/model/bootc-page.ts
@@ -135,6 +135,9 @@ export class BootcPage {
         await playExpect(this.arm64Button).toBeEnabled();
         await this.arm64Button.click();
         break;
+      case ArchitectureType.Default:
+        // No action needed for default architecture
+        break;
       default:
         throw new Error(`Unknown architecture: ${architecture}`);
     }


### PR DESCRIPTION
### What does this PR do?
Adds new e2e tests to check building of example bootable images.

### What issues does this PR fix or reference?
https://github.com/podman-desktop/extension-bootc/issues/1376
