### PR TITLE
chore: switch to officially hosted examples

### DIFF
--- a/packages/frontend/src/lib/dashboard/Dashboard.spec.ts
+++ b/packages/frontend/src/lib/dashboard/Dashboard.spec.ts
@@ -25,11 +25,11 @@ import Dashboard from './Dashboard.svelte';
 import type { ImageInfo } from '@podman-desktop/api';
 import type { Subscriber } from '/@shared/src/messages/MessageProxy';
 
-const exampleTestImage = `quay.io/bootc-extension/httpd:latest`;
+const exampleTestImage = `registry.gitlab.com/fedora/bootc/examples/httpd:latest`;
 
 const mockBootcImages: ImageInfo[] = [
   {
-    Id: 'quay.io/bootc-extension/httpd',
+    Id: 'registry.gitlab.com/fedora/bootc/examples/httpd',
     RepoTags: [exampleTestImage],
     Labels: {
       bootc: 'true',

--- a/packages/frontend/src/lib/dashboard/Dashboard.svelte
+++ b/packages/frontend/src/lib/dashboard/Dashboard.svelte
@@ -23,7 +23,7 @@ let displayDisclaimer = $state(false);
 let bootcImageCount = $derived($imageInfo.length);
 let diskImageCount = $derived($historyInfo.length);
 
-const exampleImage = 'quay.io/bootc-extension/httpd:latest';
+const exampleImage = 'registry.gitlab.com/fedora/bootc/examples/httpd:latest';
 const bootcImageBuilderSite = 'https://github.com/osbuild/bootc-image-builder';
 const bootcSite = 'https://bootc-dev.github.io/bootc/';
 const fedoraBaseImages = 'https://docs.fedoraproject.org/en-US/bootc/base-images/';
@@ -56,7 +56,7 @@ async function pullExampleImage(): Promise<void> {
   });
 }
 
-// Each time images updates, check if 'quay.io/bootc-extension/httpd' is in RepoTags
+// Each time images updates, check if 'registry.gitlab.com/fedora/bootc/examples/httpd' is in RepoTags
 let imageExists = $derived($imageInfo?.some(image => image.RepoTags?.includes(exampleImage)));
 </script>
 


### PR DESCRIPTION
chore: switch to officially hosted examples

### What does this PR do?

The examples on the fedora bootc gitlab
(https://gitlab.com/fedora/bootc/examples) are now hosted for both arm64
and amd64.

We can now replace our own "self maintained" examples with the official
examples which are better maintained.

This has been tested and you can see there are both image architectures
available:

```sh
▶ podman pull registry.gitlab.com/fedora/bootc/examples/httpd:latest --platform linux/arm64
Trying to pull registry.gitlab.com/fedora/bootc/examples/httpd:latest...
Getting image source signatures
Copying blob sha256:c592249cccb1f5c0a13ab4f62723b5ad4cdc85e68382963d757f0e9a62d4be84
Copying blob sha256:7c50fb37076aedf81eccd41a3ca88071f1aa74b1b235db858836661b7ac6369d
Copying blob sha256:c27533c1aed2a68e76bdfb2e57a50fffe6e7cf4f3da3dcecb9af4e41eb8f8dac
Copying blob sha256:7adda3a6684b48d3d054bdede727d37980cefa986c40ecf8fd6bc8ec11540041
Copying blob sha256:1be6be164bbd6705807fb07de5310646da50330bb137e6b3a5f231a33312af58
Copying blob sha256:6fa72cea1c62f531c6dbdbe4107e437dfb0a04cfbfa479b5781269f4b34c108a
Copying blob sha256:cc8749a253d9477f9303b71fc21c0289ae290ffe7dc718271627bf14005fc9b4
^C

~                                                                                                                                                       ⍉
▶ podman pull registry.gitlab.com/fedora/bootc/examples/httpd:latest --platform linux/amd64
Trying to pull registry.gitlab.com/fedora/bootc/examples/httpd:latest...
Getting image source signatures
Copying blob sha256:845696168d9042d2cc4ebe4091f2e1c41f8c406dbd3d0f142df021b4513cda95
Copying blob sha256:a6ee17e300437f1b8df07b254a42e94cf5920f021842db86b61622779e39eeec
Copying blob sha256:dd6b8d207585dad2c500a2f5932911b4766e20864afb6df4de987c6c044f1c08
Copying blob sha256:7c50fb37076aedf81eccd41a3ca88071f1aa74b1b235db858836661b7ac6369d
Copying blob sha256:c7a5fe793d7ff82e3797660f6eb8dff6be80df50bb81790417785095ba919985
Copying blob sha256:8bfc0e089ba960376546754faa80b7c7d704f68302bd5830ec5d5f5c46014047
```

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

![Screenshot 2025-04-03 at 10 31 50 AM](https://github.com/user-attachments/assets/f17b62a5-e22f-44ee-b5af-8c2dcf23c8da)


### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/podman-desktop/extension-bootc/issues/240

### How to test this PR?

See that there is a new example to download.

<!-- Please explain steps to reproduce -->

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
