### PR TITLE
chore: small check, do prereqs before building

### DIFF
--- a/packages/frontend/src/Build.spec.ts
+++ b/packages/frontend/src/Build.spec.ts
@@ -912,3 +912,34 @@ test('expect anaconda kickstart file section to be shown', async () => {
   const anacondaKickstart = screen.getByLabelText('anaconda-iso-installer-kickstart-file-title');
   expect(anacondaKickstart).toBeDefined();
 });
+
+test('on mount, expect checkPrereqs to be called', async () => {
+  vi.mocked(bootcClient.checkPrereqs).mockResolvedValue(undefined);
+  render(Build);
+
+  // Wait until children length is 2 meaning it's fully rendered / propagated the changes
+  await vi.waitFor(() => {
+    if (screen.getByLabelText('image-select')?.children.length !== 2) {
+      throw new Error();
+    }
+  });
+
+  expect(bootcClient.checkPrereqs).toHaveBeenCalled();
+});
+
+test('purposely fail prereqs, expect an error to show going to build', async () => {
+  const prereq = 'We failed the prereq connection check';
+  vi.mocked(bootcClient.checkPrereqs).mockRejectedValue(prereq);
+  render(Build);
+
+  // Wait for the error message to appear
+  await vi.waitFor(() => {
+    // Wait for heading name 'Error with image build' to appear
+    const errorHeading = screen.getByText('Error with image build');
+    expect(errorHeading).toBeDefined();
+
+    // Expect prereq error message to be shown
+    const errorMessage = screen.getByText(prereq);
+    expect(errorMessage).toBeDefined();
+  });
+});

--- a/packages/frontend/src/Build.svelte
+++ b/packages/frontend/src/Build.svelte
@@ -152,7 +152,16 @@ async function fillChownOption(): Promise<void> {
 }
 
 async function validate(): Promise<void> {
-  let prereqs = await bootcClient.checkPrereqs();
+  let prereqs;
+  // Wrapped around a try / catch so we do not have any unhandled promise rejections
+  try {
+    prereqs = await bootcClient.checkPrereqs();
+  } catch (err) {
+    errorFormValidation = String(err);
+    existingBuild = false;
+    return;
+  }
+
   if (prereqs) {
     errorFormValidation = prereqs;
     existingBuild = false;
@@ -415,6 +424,13 @@ onMount(async () => {
 
   // filter to images that have a repo tag here, to avoid doing it everywhere
   bootcAvailableImages = images.filter(image => image.RepoTags && image.RepoTags.length > 0);
+
+  // On mount do prerequisite check to see if podman machine is running correctly and then return the error message.
+  try {
+    await bootcClient.checkPrereqs();
+  } catch (error) {
+    buildErrorMessage = String(error);
+  }
 
   // Fills the build options with the last options
   await fillBuildOptions($historyInfo);

--- a/packages/frontend/src/Build.svelte
+++ b/packages/frontend/src/Build.svelte
@@ -156,7 +156,7 @@ async function validate(): Promise<void> {
   // Wrapped around a try / catch so we do not have any unhandled promise rejections
   try {
     prereqs = await bootcClient.checkPrereqs();
-  } catch (err) {
+  } catch (err: unknown) {
     errorFormValidation = String(err);
     existingBuild = false;
     return;
@@ -428,8 +428,9 @@ onMount(async () => {
   // On mount do prerequisite check to see if podman machine is running correctly and then return the error message.
   try {
     await bootcClient.checkPrereqs();
-  } catch (error) {
-    buildErrorMessage = String(error);
+  } catch (err: unknown) {
+    buildErrorMessage = String(err);
+    return;
   }
 
   // Fills the build options with the last options


### PR DESCRIPTION
chore: small check, do prereqs before building

### What does this PR do?

On the build page, we should do a prereqs check to see if the podman
machine is even running.

This adds a prereq check at the beginning to make sure that it errors
out before the user fills out the form.

I have also made sure that validation is now captures inside of a try /
catch, which it wasn't before.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

![Screenshot 2025-04-04 at 9 07 26 AM](https://github.com/user-attachments/assets/a0945fbf-a8da-490e-bef7-58360d9ade4a)

No need to checks elsewhere, as we have error outputs when trying to pull:
![Screenshot 2025-04-04 at 9 07 40 AM](https://github.com/user-attachments/assets/5fa17171-31bf-4e77-9c88-5727b00bff2f)



### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/podman-desktop/extension-bootc/issues/701

### How to test this PR?

<!-- Please explain steps to reproduce -->

1. Purposely stop podman machine
2. Go to build
3. See it errors out when trying to press button.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
