### PR TITLE
chore: navigation api for image build

### DIFF
--- a/packages/frontend/src/lib/dashboard/Dashboard.svelte
+++ b/packages/frontend/src/lib/dashboard/Dashboard.svelte
@@ -2,7 +2,6 @@
 import BootcSelkie from '../BootcSelkie.svelte';
 import Link from '../Link.svelte';
 import { faArrowCircleDown, faCube } from '@fortawesome/free-solid-svg-icons';
-import { router } from 'tinro';
 import { tick } from 'svelte';
 import { bootcClient } from '../../api/client';
 import { Button, Expandable } from '@podman-desktop/ui-svelte';
@@ -16,6 +15,7 @@ import osbuildImage from './osbuild.png';
 import redhatImage from './redhat.png';
 import fedoraImage from './fedora.png';
 import BootcImageIcon from '../BootcImageIcon.svelte';
+import { gotoImageBuild } from '../navigation';
 
 let pullInProgress = $state(false);
 let displayDisclaimer = $state(false);
@@ -30,11 +30,10 @@ const fedoraBaseImages = 'https://docs.fedoraproject.org/en-US/bootc/base-images
 const extensionSite = 'https://github.com/containers/podman-desktop-extension-bootc';
 
 async function gotoBuild(): Promise<void> {
-  // Split the image name to get the image name and tag
-  // and go to /disk-image/build/:image/:tag
+  // Split the image name to get the image name and tag and go to build page
   // this will pre-select the image and tag in the build screen
   const [image, tag] = exampleImage.split(':');
-  router.goto(`/disk-images/build/${encodeURIComponent(image)}/${encodeURIComponent(tag)}`);
+  await gotoImageBuild(image, tag);
 }
 
 async function pullExampleImage(): Promise<void> {

--- a/packages/frontend/src/lib/examples/ExampleCard.svelte
+++ b/packages/frontend/src/lib/examples/ExampleCard.svelte
@@ -7,6 +7,7 @@ import { router } from 'tinro';
 import DiskImageIcon from '../DiskImageIcon.svelte';
 import { filesize } from 'filesize';
 import { onMount } from 'svelte';
+import { gotoImageBuild } from '../navigation';
 
 interface Props {
   example: Example;
@@ -34,7 +35,7 @@ async function pullImage(arch?: string): Promise<void> {
 async function gotoBuild(): Promise<void> {
   if (example.image && example.tag) {
     await bootcClient.telemetryLogUsage('example-build-image', { image: example.image });
-    router.goto(`/disk-images/build/${encodeURIComponent(example.image)}/${encodeURIComponent(example.tag)}`);
+    await gotoImageBuild(example.image, example.tag);
   }
 }
 

--- a/packages/frontend/src/lib/navigation.ts
+++ b/packages/frontend/src/lib/navigation.ts
@@ -26,3 +26,8 @@ export async function gotoBuild(): Promise<void> {
   await bootcClient.telemetryLogUsage('nav-build');
   router.goto('/disk-images/build');
 }
+
+export async function gotoImageBuild(name: string, tag: string): Promise<void> {
+  await bootcClient.telemetryLogUsage('nav-build');
+  router.goto(`/disk-images/build/${encodeURIComponent(name)}/${encodeURIComponent(tag)}`);
+}


### PR DESCRIPTION
### What does this PR do?

I noticed two places where we have the navigation route for opening the build page with an image preselected, and we'll need a third for the coming images page.

This just adds it to the navigation api to avoid copy/paste and keep uris in one place. I looked at overriding gotoBuild function instead of providing a new function, but seemed simpler to me this way.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Part of #862.

### How to test this PR?

Just quick code review.