### PR TITLE
chore: update rhel bootc-image-builder image

### DIFF
--- a/packages/backend/src/constants.ts
+++ b/packages/backend/src/constants.ts
@@ -20,4 +20,4 @@
 export const bootcImageBuilder = 'bootc-image-builder';
 export const bootcImageBuilderCentos =
   'quay.io/centos-bootc/bootc-image-builder:sha256-e53a3916cfc416f00a54a93757d7a48beb1af7fce3a3a329d07a0eea2e2b0737';
-export const bootcImageBuilderRHEL = 'registry.redhat.io/rhel9/bootc-image-builder:9.4';
+export const bootcImageBuilderRHEL = 'registry.redhat.io/rhel9/bootc-image-builder:9.5';


### PR DESCRIPTION
chore: update rhel bootc-image-builder image

### What does this PR do?

* Update the rhel bootc-image-builder image to 9.5 over 9.4
* Confirmed working with fedora / centos / rhel 10 building.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

N/A

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Part of https://github.com/podman-desktop/extension-bootc/issues/1363

### How to test this PR?

<!-- Please explain steps to reproduce -->

1. Change the default setting for image builder to the RHEL one
2. Build any image (fedora, centos, etc.)
3. Builds with no errors.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
