### PR TITLE
chore: extract first image component

### DIFF
--- a/packages/frontend/src/lib/FirstImage.svelte
+++ b/packages/frontend/src/lib/FirstImage.svelte
@@ -1,0 +1,69 @@
+<script lang="ts">
+import Link from './Link.svelte';
+import { faArrowCircleDown, faCube } from '@fortawesome/free-solid-svg-icons';
+import { tick } from 'svelte';
+import { bootcClient } from '/@/api/client';
+import { Button } from '@podman-desktop/ui-svelte';
+import { imageInfo } from '../stores/imageInfo';
+import { gotoImageBuild } from './navigation';
+
+let pullInProgress = $state(false);
+let displayDisclaimer = $state(false);
+
+const exampleImage = 'registry.gitlab.com/fedora/bootc/examples/httpd:latest';
+
+async function gotoBuild(): Promise<void> {
+  // Split the image name to get the image name and tag and go to build page
+  // this will pre-select the image and tag in the build screen
+  const [image, tag] = exampleImage.split(':');
+  await gotoImageBuild(image, tag);
+}
+
+async function pullExampleImage(): Promise<void> {
+  pullInProgress = true;
+  displayDisclaimer = false;
+
+  // After 5 seconds, check if pull is still in progress and display disclaimer if true
+  setTimeout(() => {
+    if (pullInProgress) {
+      displayDisclaimer = true;
+      // Ensure UI updates to reflect the new state
+      tick().catch((e: unknown) => console.error('error updating disclaimer', e));
+    }
+  }, 5_000);
+
+  await bootcClient.pullImage(exampleImage).finally(() => {
+    pullInProgress = false;
+    displayDisclaimer = false;
+  });
+}
+
+// Each time images updates, check if the image is in RepoTags
+let imageExists = $derived($imageInfo?.some(image => image.RepoTags?.includes(exampleImage)));
+</script>
+
+<div class="flex flex-col">
+  <p class="pb-1 max-w-xl text-[var(--pd-card-header-text)]">
+    Create your first disk image by {imageExists ? 'building' : 'pulling'} the <Link
+      externalRef={`https://${exampleImage}`}>example container image</Link
+    >:
+  </p>
+
+  <!-- Build / pull buttons -->
+  {#if imageExists}
+    <Button on:click={gotoBuild} icon={faCube} aria-label="Build image" title="Build"
+      >Build {exampleImage}</Button>
+  {:else}
+    <Button
+      on:click={pullExampleImage}
+      icon={faArrowCircleDown}
+      inProgress={pullInProgress}
+      aria-label="Pull image"
+      title="Pull image">Pull {exampleImage}</Button>
+  {/if}
+  {#if displayDisclaimer}
+    <p class="text-[var(--pd-status-waiting)] text-sm">
+      The file size of the image is over 1.5GB and may take a while to download.
+    </p>
+  {/if}
+</div>

--- a/packages/frontend/src/lib/dashboard/Dashboard.svelte
+++ b/packages/frontend/src/lib/dashboard/Dashboard.svelte
@@ -1,10 +1,7 @@
 <script lang="ts">
 import BootcSelkie from '../BootcSelkie.svelte';
 import Link from '../Link.svelte';
-import { faArrowCircleDown, faCube } from '@fortawesome/free-solid-svg-icons';
-import { tick } from 'svelte';
-import { bootcClient } from '../../api/client';
-import { Button, Expandable } from '@podman-desktop/ui-svelte';
+import { Expandable } from '@podman-desktop/ui-svelte';
 import DashboardPage from '../upstream/DashboardPage.svelte';
 import DashboardResourceCard from '../upstream/DashboardResourceCard.svelte';
 import DiskImageIcon from '../DiskImageIcon.svelte';
@@ -15,48 +12,15 @@ import osbuildImage from './osbuild.png';
 import redhatImage from './redhat.png';
 import fedoraImage from './fedora.png';
 import BootcImageIcon from '../BootcImageIcon.svelte';
-import { gotoImageBuild } from '../navigation';
-
-let pullInProgress = $state(false);
-let displayDisclaimer = $state(false);
+import FirstImage from '../FirstImage.svelte';
 
 let bootcImageCount = $derived($imageInfo.length);
 let diskImageCount = $derived($historyInfo.length);
 
-const exampleImage = 'registry.gitlab.com/fedora/bootc/examples/httpd:latest';
 const bootcImageBuilderSite = 'https://github.com/osbuild/bootc-image-builder';
 const bootcSite = 'https://bootc-dev.github.io/bootc/';
 const fedoraBaseImages = 'https://docs.fedoraproject.org/en-US/bootc/base-images/';
 const extensionSite = 'https://github.com/containers/podman-desktop-extension-bootc';
-
-async function gotoBuild(): Promise<void> {
-  // Split the image name to get the image name and tag and go to build page
-  // this will pre-select the image and tag in the build screen
-  const [image, tag] = exampleImage.split(':');
-  await gotoImageBuild(image, tag);
-}
-
-async function pullExampleImage(): Promise<void> {
-  pullInProgress = true;
-  displayDisclaimer = false;
-
-  // After 5 seconds, check if pull is still in progress and display disclaimer if true
-  setTimeout(() => {
-    if (pullInProgress) {
-      displayDisclaimer = true;
-      // Ensure UI updates to reflect the new state
-      tick().catch((e: unknown) => console.error('error updating disclaimer', e));
-    }
-  }, 5_000);
-
-  await bootcClient.pullImage(exampleImage).finally(() => {
-    pullInProgress = false;
-    displayDisclaimer = false;
-  });
-}
-
-// Each time images updates, check if 'registry.gitlab.com/fedora/bootc/examples/httpd' is in RepoTags
-let imageExists = $derived($imageInfo?.some(image => image.RepoTags?.includes(exampleImage)));
 </script>
 
 <DashboardPage>
@@ -86,29 +50,7 @@ let imageExists = $derived($imageInfo?.some(image => image.RepoTags?.includes(ex
   {/snippet}
 
   <div class="flex flex-col items-center text-center space-y-3 p-4 bg-[var(--pd-content-card-carousel-card-bg)] rounded-md">
-    <p class="pb-1 max-w-xl text-[var(--pd-card-header-text)]">
-      Create your first disk image by {imageExists ? 'building' : 'pulling'} the <Link
-        externalRef={`https://${exampleImage}`}>example container image</Link
-      >:
-    </p>
-
-    <!-- Build / pull buttons -->
-    {#if imageExists}
-      <Button on:click={gotoBuild} icon={faCube} aria-label="Build image" title="Build"
-        >Build {exampleImage}</Button>
-    {:else}
-      <Button
-        on:click={pullExampleImage}
-        icon={faArrowCircleDown}
-        inProgress={pullInProgress}
-        aria-label="Pull image"
-        title="Pull image">Pull {exampleImage}</Button>
-    {/if}
-    {#if displayDisclaimer}
-      <p class="text-[var(--pd-status-waiting)] text-sm">
-        The file size of the image is over 1.5GB and may take a while to download.
-      </p>
-    {/if}
+    <FirstImage/>
   </div>
 
   <div class="text-xl pt-2">Metrics</div>


### PR DESCRIPTION
### What does this PR do?

I want to use the same 'load first image' controls on the bootable image empty screen as what we have on the Dashboard today. This just extracts the UI elements out of the Dashboard and into its own reusable component, which is better code separation anyway.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Part of #862.

### How to test this PR?

Just code review.