### PR TITLE
fix: update responsive breakpoints to avoid example overflow

### DIFF
--- a/packages/frontend/src/lib/examples/ExamplesCard.svelte
+++ b/packages/frontend/src/lib/examples/ExamplesCard.svelte
@@ -42,7 +42,7 @@ $effect(() => {
 
 <Card title={category.name}>
   <div class="w-full">
-    <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4 mt-4">
+    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 mt-4">
       {#each examples as example (example.id)}
         <ExampleCard example={example} />
       {/each}


### PR DESCRIPTION
### What does this PR do?

The More Details button doesn't fit within the example cards where the cards are too narrow. Instead of changing the design, simple fix is just to bump the responsive breakpoints so that the cards never get quite as narrow.

### Screenshot / video of UI

Before:

![image](https://github.com/user-attachments/assets/8151131b-f783-422c-8843-7a5d2400ba02)

After:

https://github.com/user-attachments/assets/914ebd0d-bd8c-4d82-8465-2d3b10e552dd

### What issues does this PR fix or reference?

Fixes #1505.

### How to test this PR?

Go to Examples page and try it at different widths.