### PR TITLE
chore(test): revert heading validation change

### DIFF
--- a/tests/playwright/src/bootc-extension.spec.ts
+++ b/tests/playwright/src/bootc-extension.spec.ts
@@ -97,7 +97,6 @@ test.describe('BootC Extension', () => {
     test.setTimeout(200_000);
 
     const extensionsPage = await navigationBar.openExtensions();
-    await playExpect(extensionsPage.heading).toBeVisible();
     await extensionsPage.installExtensionFromOCIImage('ghcr.io/podman-desktop/podman-desktop-extension-bootc:nightly');
 
     await playExpect


### PR DESCRIPTION
### What does this PR do?
Revers a previous change that broke e2e test navigation validation

### What issues does this PR fix or reference?

