### PR TITLE
chore: bootable image status icon

### DIFF
--- a/packages/frontend/src/lib/BootcStatusIcon.spec.ts
+++ b/packages/frontend/src/lib/BootcStatusIcon.spec.ts
@@ -66,3 +66,12 @@ test('Expect lost status to display amber background', async () => {
   expect(icon).toHaveAttribute('title', status);
   expect(icon).toHaveClass('bg-[var(--pd-status-degraded)]');
 });
+
+test('Expect used status to display green background', async () => {
+  const status = 'used';
+  render(BootcStatusIcon, { status });
+  const icon = screen.getByRole('status');
+  expect(icon).toBeInTheDocument();
+  expect(icon).toHaveAttribute('title', status);
+  expect(icon).toHaveClass('bg-[var(--pd-status-running)]');
+});

--- a/packages/frontend/src/lib/BootcStatusIcon.svelte
+++ b/packages/frontend/src/lib/BootcStatusIcon.svelte
@@ -15,13 +15,14 @@ $: solid =
   status === 'error' ||
   status === 'lost' ||
   status === 'creating' ||
+  status === 'used' ||
   status === 'deleting';
 </script>
 
 <div class="grid place-content-center" style="position:relative">
   <div
     class="grid place-content-center rounded-sm aspect-square text-xs"
-    class:bg-[var(--pd-status-running)]={status === 'success'}
+    class:bg-[var(--pd-status-running)]={status === 'success' || status === 'used'}
     class:bg-[var(--pd-status-created)]={status === 'running'}
     class:bg-[var(--pd-status-terminated)]={status === 'error'}
     class:bg-[var(--pd-status-degraded)]={status === 'lost'}


### PR DESCRIPTION
### What does this PR do?

As we add images to the UI we'll need the status icon to support two new states: used and unused. Unused doesn't require any changes (it's the default styling) but used needs to be treated the same way as 'success' for disk images.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Part of #862.

### How to test this PR?

PR checks, code review.