### PR TITLE
feat: bootable images page

### DIFF
--- a/packages/frontend/src/App.svelte
+++ b/packages/frontend/src/App.svelte
@@ -13,6 +13,7 @@ import Navigation from './Navigation.svelte';
 import DiskImagesList from './lib/disk-image/DiskImagesList.svelte';
 import Dashboard from './lib/dashboard/Dashboard.svelte';
 import ExampleDetails from './lib/examples/ExampleDetails.svelte';
+import ImagesList from './lib/images/ImagesList.svelte';
 
 router.mode.hash();
 
@@ -44,6 +45,9 @@ onMount(() => {
 
       <Route path="/example/:id" breadcrumb="Example Details" let:meta>
         <ExampleDetails id={meta.params.id} />
+      </Route>
+      <Route path="/images/" breadcrumb="Images">
+        <ImagesList />
       </Route>
       <Route path="/disk-images/" breadcrumb="Disk Images">
         <DiskImagesList />

--- a/packages/frontend/src/Navigation.svelte
+++ b/packages/frontend/src/Navigation.svelte
@@ -15,6 +15,7 @@ export let meta: TinroRouteMeta;
   </div>
   <div class="h-full overflow-hidden hover:overflow-y-auto" style="margin-bottom:auto">
     <SettingsNavItem title="Dashboard" selected={meta.url === '/'} href="/" />
+    <SettingsNavItem title="Images" selected={meta.url.startsWith('/images')} href="/images" />
     <SettingsNavItem title="Disk Images" selected={meta.url.startsWith('/disk-image')} href="/disk-images" />
     <SettingsNavItem title="Examples" selected={meta.url.startsWith('/examples')} href="/examples" />
   </div>

--- a/packages/frontend/src/lib/dashboard/Dashboard.svelte
+++ b/packages/frontend/src/lib/dashboard/Dashboard.svelte
@@ -55,7 +55,7 @@ const extensionSite = 'https://github.com/containers/podman-desktop-extension-bo
 
   <div class="text-xl pt-2">Metrics</div>
   <div class="grid grid-cols-4 gap-4">
-    <DashboardResourceCard type="Bootc Images" Icon={BootcImageIcon} count={bootcImageCount} link="/" />
+    <DashboardResourceCard type="Bootc Images" Icon={BootcImageIcon} count={bootcImageCount} link="/images/" />
     <DashboardResourceCard type="Disk Images" Icon={DiskImageIcon} count={diskImageCount} link="/disk-images/" />
   </div>
 

--- a/packages/frontend/src/lib/images/ImageActions.spec.ts
+++ b/packages/frontend/src/lib/images/ImageActions.spec.ts
@@ -1,0 +1,48 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { render, screen } from '@testing-library/svelte';
+import { expect, test, vi } from 'vitest';
+import type { ImageInfoUI } from './ImageInfoUI';
+import ImageActions from './ImageActions.svelte';
+import userEvent from '@testing-library/user-event';
+import { gotoImageBuild } from '../navigation';
+
+vi.mock('../navigation', async () => {
+  return {
+    gotoImageBuild: vi.fn(),
+  };
+});
+
+test('Expect Build image action ', async () => {
+  const image: ImageInfoUI = {
+    name: 'dummy',
+    status: 'unused',
+  } as ImageInfoUI;
+
+  render(ImageActions, { object: image });
+
+  const build = screen.getByTitle('Build Disk Image');
+  expect(build).toBeDefined();
+
+  await userEvent.click(build);
+
+  expect(gotoImageBuild).toHaveBeenCalled();
+});

--- a/packages/frontend/src/lib/images/ImageActions.svelte
+++ b/packages/frontend/src/lib/images/ImageActions.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+import ListItemButtonIcon from '/@/lib/upstream/ListItemButtonIcon.svelte';
+import type { ImageInfoUI } from './ImageInfoUI';
+import { faBuilding } from '@fortawesome/free-solid-svg-icons';
+import { gotoImageBuild } from '../navigation';
+
+interface Props {
+  object: ImageInfoUI;
+}
+
+let { object }: Props = $props();
+
+async function goToImageBuild(): Promise<void> {
+  await gotoImageBuild(object.name, object.tag);
+}
+</script>
+
+<ListItemButtonIcon title="Build Disk Image" onClick={goToImageBuild} icon={faBuilding} />

--- a/packages/frontend/src/lib/images/ImageEmptyScreen.spec.ts
+++ b/packages/frontend/src/lib/images/ImageEmptyScreen.spec.ts
@@ -1,0 +1,57 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { render, screen } from '@testing-library/svelte';
+import { expect, test, vi } from 'vitest';
+
+import ImageEmptyScreen from './ImageEmptyScreen.svelte';
+import type { Subscriber } from '/@shared/src/messages/MessageProxy';
+import { bootcClient } from '/@/api/client';
+
+vi.mock('/@/api/client', async () => {
+  return {
+    bootcClient: {
+      listBootcImages: vi.fn(),
+    },
+    rpcBrowser: {
+      subscribe: (): Subscriber => {
+        return {
+          unsubscribe: (): void => {},
+        };
+      },
+    },
+  };
+});
+
+test('Expect basic content', async () => {
+  vi.mocked(bootcClient.listBootcImages).mockResolvedValue([]);
+  render(ImageEmptyScreen);
+
+  const title = screen.getByText('No bootable container images');
+  expect(title).toBeInTheDocument();
+});
+
+test('Expect page to contain pull image button', async () => {
+  vi.mocked(bootcClient.listBootcImages).mockResolvedValue([]);
+  render(ImageEmptyScreen);
+
+  const pullButton = screen.getByRole('button', { name: 'Pull image' });
+  expect(pullButton).toBeInTheDocument();
+});

--- a/packages/frontend/src/lib/images/ImageEmptyScreen.svelte
+++ b/packages/frontend/src/lib/images/ImageEmptyScreen.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+import { EmptyScreen } from '@podman-desktop/ui-svelte';
+import FirstImageScreen from '../FirstImage.svelte';
+import BootcImageIcon from '../BootcImageIcon.svelte';
+</script>
+
+<EmptyScreen
+  icon={BootcImageIcon}
+  title="No bootable container images">
+  <div slot="upperContent">
+    <FirstImageScreen/>
+  </div>
+</EmptyScreen>

--- a/packages/frontend/src/lib/images/ImagesList.spec.ts
+++ b/packages/frontend/src/lib/images/ImagesList.spec.ts
@@ -1,0 +1,106 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { render, screen } from '@testing-library/svelte';
+import { expect, test, vi } from 'vitest';
+import type { ImageInfo } from '@podman-desktop/api';
+
+import ImagesList from './ImagesList.svelte';
+import type { Subscriber } from '/@shared/src/messages/MessageProxy';
+import { bootcClient } from '/@/api/client';
+
+vi.mock('/@/api/client', async () => {
+  return {
+    bootcClient: {
+      listBootcImages: vi.fn(),
+    },
+    rpcBrowser: {
+      subscribe: (): Subscriber => {
+        return {
+          unsubscribe: (): void => {},
+        };
+      },
+    },
+  };
+});
+
+test('Expect no images', async () => {
+  vi.mocked(bootcClient.listBootcImages).mockResolvedValue([]);
+  render(ImagesList);
+
+  const title = screen.getByText('No bootable container images');
+  expect(title).toBeInTheDocument();
+});
+
+test('Expect images being ordered by name', async () => {
+  vi.mocked(bootcClient.listBootcImages).mockResolvedValue([
+    {
+      Id: 'sha256:45645645645656',
+      RepoTags: ['image2:latest'],
+      Created: 123,
+      Size: 123,
+    },
+    {
+      Id: 'sha256:789789123456783',
+      RepoTags: ['image3:recent'],
+      Created: 123,
+      Size: 123,
+    },
+    {
+      Id: 'sha256:12345678901234',
+      RepoTags: ['image1:old'],
+      Created: 123,
+      Size: 123,
+    },
+  ] as ImageInfo[]);
+
+  render(ImagesList);
+
+  await vi.waitFor(() => {
+    screen.getByText('image1');
+  });
+
+  const image1 = screen.getByText('image1');
+  const image2 = screen.getByText('image2');
+  const image3 = screen.getByText('image3');
+  expect(image1).toBeInTheDocument();
+  expect(image2).toBeInTheDocument();
+  expect(image3).toBeInTheDocument();
+
+  expect(image3.compareDocumentPosition(image1)).toBe(2);
+  expect(image3.compareDocumentPosition(image2)).toBe(2);
+  expect(image1.compareDocumentPosition(image2)).toBe(4);
+});
+
+test('Expect filter empty screen', async () => {
+  vi.mocked(bootcClient.listBootcImages).mockResolvedValue([
+    {
+      Id: 'sha256:1234567890123',
+      RepoTags: ['fedora:old'],
+      Created: 1644009612,
+      Size: 123,
+    },
+  ] as ImageInfo[]);
+
+  render(ImagesList, { searchTerm: 'No match' });
+
+  const filterButton = screen.getByRole('button', { name: 'Clear filter' });
+  expect(filterButton).toBeInTheDocument();
+});

--- a/packages/frontend/src/lib/images/ImagesList.svelte
+++ b/packages/frontend/src/lib/images/ImagesList.svelte
@@ -1,0 +1,106 @@
+<script lang="ts">
+import {
+  FilteredEmptyScreen,
+  NavPage,
+  Table,
+  TableColumn,
+  TableDurationColumn,
+  TableRow,
+  TableSimpleColumn,
+} from '@podman-desktop/ui-svelte';
+import { onMount } from 'svelte';
+import { ImageUtils } from './image-utils';
+import { filtered, searchPattern } from '/@/stores/imageInfo';
+import type { ImageInfoUI } from './ImageInfoUI';
+import Status from './columns/Status.svelte';
+import Name from './columns/Name.svelte';
+import Actions from './columns/Actions.svelte';
+import moment from 'moment';
+import BootcImageIcon from '../BootcImageIcon.svelte';
+import ImageEmptyScreen from './ImageEmptyScreen.svelte';
+import { filesize } from 'filesize';
+
+interface Props {
+  searchTerm?: string;
+}
+let { searchTerm = '' }: Props = $props();
+
+$effect(() => {
+  searchPattern.set(searchTerm);
+});
+
+let images = $state<ImageInfoUI[]>([]);
+
+const imageUtils = new ImageUtils();
+
+onMount(() => {
+  return filtered.subscribe(value => {
+    images = value.map(image => imageUtils.getImagesInfoUI(image, [])).flat();
+  });
+});
+
+let selectedItemsNumber = $state<number>(0);
+let table: Table;
+
+let statusColumn = new TableColumn<ImageInfoUI>('Status', {
+  align: 'center',
+  width: '70px',
+  renderer: Status,
+  comparator: (a, b): number => b.status.localeCompare(a.status),
+});
+
+let nameColumn = new TableColumn<ImageInfoUI>('Name', {
+  width: '4fr',
+  renderer: Name,
+  comparator: (a, b): number => a.name.localeCompare(b.name),
+});
+
+let ageColumn = new TableColumn<ImageInfoUI, Date>('Age', {
+  renderMapping: (image): Date => image.created,
+  renderer: TableDurationColumn,
+  comparator: (a, b): number => moment(b.created).diff(moment(a.created)),
+});
+
+let sizeColumn = new TableColumn<ImageInfoUI, string>('Size', {
+  align: 'right',
+  renderMapping: (image): string => filesize(image.size),
+  renderer: TableSimpleColumn,
+  comparator: (a, b): number => b.size - a.size,
+});
+
+const columns = [
+  statusColumn,
+  nameColumn,
+  ageColumn,
+  sizeColumn,
+  new TableColumn<ImageInfoUI>('Actions', { align: 'right', renderer: Actions, overflow: true }),
+];
+
+const row = new TableRow<ImageInfoUI>({
+  // If it is a manifest, it is not selectable (no delete functionality yet)
+  selectable: (image): boolean => image.status === 'unused' && !image.isManifest,
+  disabledText: 'Image is used by a container',
+});
+</script>
+
+<NavPage bind:searchTerm={searchTerm} title="images">
+  <div class="flex min-w-full h-full" slot="content">
+    <Table
+      kind="image"
+      bind:this={table}
+      bind:selectedItemsNumber={selectedItemsNumber}
+      data={images}
+      columns={columns}
+      row={row}
+      defaultSortColumn="Name">
+    </Table>
+
+    {#if $filtered.length === 0}
+      {#if searchTerm}
+        <FilteredEmptyScreen icon={BootcImageIcon} kind="images" bind:searchTerm={searchTerm} />
+      {:else}
+        <ImageEmptyScreen />
+      {/if}
+    {/if}
+  </div>
+</NavPage>

--- a/packages/frontend/src/lib/images/columns/Actions.svelte
+++ b/packages/frontend/src/lib/images/columns/Actions.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+import ImageActions from '../ImageActions.svelte';
+import type { Props } from './props';
+
+let { object }: Props = $props();
+</script>
+
+<ImageActions object={object} />

--- a/packages/frontend/src/lib/images/columns/Name.spec.ts
+++ b/packages/frontend/src/lib/images/columns/Name.spec.ts
@@ -1,0 +1,50 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { render, screen } from '@testing-library/svelte';
+import { expect, test } from 'vitest';
+
+import Name from './Name.svelte';
+import type { ImageInfoUI } from '../ImageInfoUI';
+
+const image: ImageInfoUI = {
+  name: 'my-image',
+  shortId: 'short-id',
+  tag: 'latest',
+} as ImageInfoUI;
+
+test('Expect simple column styling', async () => {
+  render(Name, { object: image });
+
+  const name = screen.getByText(image.name);
+  expect(name).toBeInTheDocument();
+  expect(name).toHaveClass('text-[var(--pd-table-body-text-highlight)]');
+  expect(name).toHaveClass('overflow-hidden');
+  expect(name).toHaveClass('text-ellipsis');
+
+  const id = screen.getByText(image.shortId);
+  expect(id).toBeInTheDocument();
+  expect(id).toHaveClass('text-[var(--pd-table-body-text-sub-secondary)]');
+
+  const tag = screen.getByText(image.tag);
+  expect(tag).toBeInTheDocument();
+  expect(tag).toHaveClass('text-[var(--pd-table-body-text)]');
+  expect(tag).toHaveClass('font-extra-light');
+});

--- a/packages/frontend/src/lib/images/columns/Name.svelte
+++ b/packages/frontend/src/lib/images/columns/Name.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+import type { Props } from './props';
+
+let { object }: Props = $props();
+</script>
+
+<button class="flex flex-col max-w-full">
+  <div class="flex flex-row gap-1 items-center max-w-full">
+    <div class="text-[var(--pd-table-body-text-highlight)] overflow-hidden text-ellipsis">
+      {object.name}
+      {object.isManifest ? ' (manifest)' : ''}
+    </div>
+  </div>
+  <div class="flex flex-row text-sm gap-1 w-full">
+    <div class="text-[var(--pd-table-body-text-sub-secondary)]">{object.shortId}</div>
+    <div class="font-extra-light text-[var(--pd-table-body-text)] overflow-hidden text-ellipsis">{object.tag}</div>
+  </div>
+</button>

--- a/packages/frontend/src/lib/images/columns/Status.spec.ts
+++ b/packages/frontend/src/lib/images/columns/Status.spec.ts
@@ -1,0 +1,50 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { render, screen } from '@testing-library/svelte';
+import { expect, test } from 'vitest';
+
+import Status from './Status.svelte';
+import type { ImageInfoUI } from '../ImageInfoUI';
+
+test('Expect simple column styling', async () => {
+  const image: ImageInfoUI = {
+    name: 'my-image',
+    status: 'unused',
+  } as ImageInfoUI;
+  render(Status, { object: image });
+
+  const text = screen.getByRole('status');
+  expect(text).toBeInTheDocument();
+  expect(text).toHaveClass('border-[var(--pd-status-not-running)]');
+  expect(text).toHaveClass('text-[var(--pd-status-not-running)]');
+});
+
+test('Expect used simple column styling', async () => {
+  const image: ImageInfoUI = {
+    name: 'my-image',
+    status: 'used',
+  } as ImageInfoUI;
+  render(Status, { object: image });
+
+  const text = screen.getByRole('status');
+  expect(text).toBeInTheDocument();
+  expect(text).toHaveClass('bg-[var(--pd-status-running)]');
+});

--- a/packages/frontend/src/lib/images/columns/Status.svelte
+++ b/packages/frontend/src/lib/images/columns/Status.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+import BootcImageIcon from '../../BootcImageIcon.svelte';
+import BootcStatusIcon from '../../BootcStatusIcon.svelte';
+import type { Props } from './props';
+
+let { object }: Props = $props();
+</script>
+
+<BootcStatusIcon icon={BootcImageIcon} status={object.status} />

--- a/packages/frontend/src/lib/images/columns/props.ts
+++ b/packages/frontend/src/lib/images/columns/props.ts
@@ -1,0 +1,23 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { ImageInfoUI } from '../ImageInfoUI';
+
+export interface Props {
+  object: ImageInfoUI;
+}


### PR DESCRIPTION
### What does this PR do?

Adds a basic bootable images page into the navigation, and linked from the Dashboard. Images just have Name, Age, Size, and a build action for now.

Things not included here, for future PRs:
- Navigation to image details (opening bug in Podman Desktop).
- Support for manifests (unclear that Podman Desktop exports enough API).
- Ability to delete images (just needs a little work).
- Images are not marked as 'used' (requires a container store).

### Screenshot / video of UI

<img width="919" alt="Screenshot 2025-04-09 at 11 11 56 AM" src="https://github.com/user-attachments/assets/b4d0e76b-307b-44a3-a823-6653e168b9a8" />

### What issues does this PR fix or reference?

Main part of #862.

### How to test this PR?

Open the Images page from the navigation and try different things, e.g. deleting all local bootc images, filtering, going to Build page.