### PR TITLE
chore: show used images via container list

### DIFF
--- a/packages/backend/src/api-impl.spec.ts
+++ b/packages/backend/src/api-impl.spec.ts
@@ -20,7 +20,7 @@ import { expect, test, vi } from 'vitest';
 import examplesCatalog from '../assets/examples.json';
 import type { ExamplesList } from '/@shared/src/models/examples';
 import { BootcApiImpl } from './api-impl';
-import type * as podmanDesktopApi from '@podman-desktop/api';
+import * as podmanDesktopApi from '@podman-desktop/api';
 
 vi.mock('@podman-desktop/api', async () => {
   return {
@@ -29,6 +29,7 @@ vi.mock('@podman-desktop/api', async () => {
     },
     containerEngine: {
       listImages: vi.fn(),
+      listContainers: vi.fn(),
     },
     env: {
       openExternal: vi.fn(),
@@ -53,4 +54,16 @@ test('getExamples should return examplesCatalog', async () => {
   expect(result.categories.length).not.toBe(0);
 
   expect(result).toEqual(examplesCatalog as ExamplesList);
+});
+
+test('listContainers should return list from extension api', async () => {
+  const containers = [{}, {}] as podmanDesktopApi.ContainerInfo[];
+
+  vi.mocked(podmanDesktopApi.containerEngine.listContainers).mockResolvedValue(containers);
+
+  const apiImpl = new BootcApiImpl({} as podmanDesktopApi.ExtensionContext, {} as podmanDesktopApi.Webview);
+  const result = await apiImpl.listContainers();
+
+  expect(podmanDesktopApi.containerEngine.listContainers).toHaveBeenCalled();
+  expect(result.length).toBe(2);
 });

--- a/packages/backend/src/api-impl.ts
+++ b/packages/backend/src/api-impl.ts
@@ -17,7 +17,7 @@
  ***********************************************************************/
 
 import * as podmanDesktopApi from '@podman-desktop/api';
-import type { ImageInfo } from '@podman-desktop/api';
+import type { ImageInfo, ContainerInfo } from '@podman-desktop/api';
 import type { BootcApi } from '/@shared/src/BootcAPI';
 import type { BootcBuildInfo, BuildType } from '/@shared/src/models/bootc';
 import { buildDiskImage, buildExists } from './build-disk-image';
@@ -229,6 +229,16 @@ export class BootcApiImpl implements BootcApi {
       console.error('Error listing images: ', err);
     }
     return images;
+  }
+
+  async listContainers(): Promise<ContainerInfo[]> {
+    try {
+      return await podmanDesktopApi.containerEngine.listContainers();
+    } catch (err) {
+      await podmanDesktopApi.window.showErrorMessage(`Error listing containers: ${err}`);
+      console.error('Error listing containers: ', err);
+      return [];
+    }
   }
 
   async inspectImage(image: ImageInfo): Promise<podmanDesktopApi.ImageInspectInfo> {

--- a/packages/frontend/src/lib/images/ImagesList.spec.ts
+++ b/packages/frontend/src/lib/images/ImagesList.spec.ts
@@ -30,6 +30,7 @@ vi.mock('/@/api/client', async () => {
   return {
     bootcClient: {
       listBootcImages: vi.fn(),
+      listContainers: vi.fn(),
     },
     rpcBrowser: {
       subscribe: (): Subscriber => {

--- a/packages/shared/src/BootcAPI.ts
+++ b/packages/shared/src/BootcAPI.ts
@@ -17,7 +17,7 @@
  l***********************************************************************/
 
 import type { BootcBuildInfo, BuildType } from './models/bootc';
-import type { ImageInfo, ImageInspectInfo, ManifestInspectInfo } from '@podman-desktop/api';
+import type { ImageInfo, ImageInspectInfo, ManifestInspectInfo, ContainerInfo } from '@podman-desktop/api';
 import type { ExamplesList } from './models/examples';
 
 export abstract class BootcApi {
@@ -35,6 +35,7 @@ export abstract class BootcApi {
   abstract selectBuildConfigFile(): Promise<string>;
   abstract selectAnacondaKickstartFile(): Promise<string>;
   abstract listBootcImages(): Promise<ImageInfo[]>;
+  abstract listContainers(): Promise<ContainerInfo[]>;
   abstract listAllImages(): Promise<ImageInfo[]>;
   abstract listHistoryInfo(): Promise<BootcBuildInfo[]>;
   abstract openFolder(folder: string): Promise<boolean>;


### PR DESCRIPTION
### What does this PR do?

Adds API for getting the list of containers and uses it in the images list. Since the requirements are simple (you can't change containers in any way within the page) it's just caching the list on mount.

### Screenshot / video of UI

<img width="919" alt="Screenshot 2025-04-09 at 12 12 31 PM" src="https://github.com/user-attachments/assets/e0349619-2e84-45dc-b67b-67a849ad9633" />

### What issues does this PR fix or reference?

Part of #862.

### How to test this PR?

Pull at least 2 images, and create a container in Podman Desktop based on one of them. The status icon and checkbox enablement should match the Images page in Podman Desktop.

API test added, status icon and other parts had tests in previous PR.