### PR TITLE
chore: delete image API

### DIFF
--- a/packages/backend/src/api-impl.spec.ts
+++ b/packages/backend/src/api-impl.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 Red Hat, Inc.
+ * Copyright (C) 2024-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ vi.mock('@podman-desktop/api', async () => {
     containerEngine: {
       listImages: vi.fn(),
       listContainers: vi.fn(),
+      deleteImage: vi.fn(),
     },
     env: {
       openExternal: vi.fn(),
@@ -66,4 +67,18 @@ test('listContainers should return list from extension api', async () => {
 
   expect(podmanDesktopApi.containerEngine.listContainers).toHaveBeenCalled();
   expect(result.length).toBe(2);
+});
+
+test('deleteImage should call the extension api and fire event', async () => {
+  const postMessageMock = vi.fn().mockResolvedValue(undefined);
+
+  const apiImpl = new BootcApiImpl(
+    {} as podmanDesktopApi.ExtensionContext,
+    { postMessage: postMessageMock } as unknown as podmanDesktopApi.Webview,
+  );
+
+  await apiImpl.deleteImage('a', 'b');
+
+  expect(podmanDesktopApi.containerEngine.deleteImage).toHaveBeenCalledWith('a', 'b');
+  expect(postMessageMock).toHaveBeenCalledWith(expect.objectContaining({ id: 'image-update' }));
 });

--- a/packages/backend/src/api-impl.ts
+++ b/packages/backend/src/api-impl.ts
@@ -197,6 +197,18 @@ export class BootcApiImpl implements BootcApi {
     return images;
   }
 
+  async deleteImage(engineId: string, id: string): Promise<void> {
+    try {
+      await podmanDesktopApi.containerEngine.deleteImage(engineId, id);
+    } catch (err) {
+      await podmanDesktopApi.window.showErrorMessage(`Error deleting image: ${err}`);
+      console.error('Error deleting image: ', err);
+    } finally {
+      // Notify the frontend the images list may have changed
+      await this.notify(Messages.MSG_IMAGE_UPDATE, {});
+    }
+  }
+
   async listBootcImages(): Promise<ImageInfo[]> {
     let images: ImageInfo[] = [];
     try {

--- a/packages/shared/src/BootcAPI.ts
+++ b/packages/shared/src/BootcAPI.ts
@@ -37,6 +37,7 @@ export abstract class BootcApi {
   abstract listBootcImages(): Promise<ImageInfo[]>;
   abstract listContainers(): Promise<ContainerInfo[]>;
   abstract listAllImages(): Promise<ImageInfo[]>;
+  abstract deleteImage(engineId: string, id: string): Promise<void>;
   abstract listHistoryInfo(): Promise<BootcBuildInfo[]>;
   abstract openFolder(folder: string): Promise<boolean>;
   abstract generateUniqueBuildID(name: string): Promise<string>;


### PR DESCRIPTION
### What does this PR do?

Adds the ability to delete images to the frontend via the Podman Desktop API.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Part of #862.

### How to test this PR?

Tests added, PR review.