### PR TITLE
feat: ability to delete images

### DIFF
--- a/packages/frontend/src/lib/images/ImageActions.svelte
+++ b/packages/frontend/src/lib/images/ImageActions.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
 import ListItemButtonIcon from '/@/lib/upstream/ListItemButtonIcon.svelte';
 import type { ImageInfoUI } from './ImageInfoUI';
-import { faBuilding } from '@fortawesome/free-solid-svg-icons';
+import { faBuilding, faTrash } from '@fortawesome/free-solid-svg-icons';
 import { gotoImageBuild } from '../navigation';
+import { bootcClient } from '/@/api/client';
 
 interface Props {
   object: ImageInfoUI;
@@ -13,6 +14,13 @@ let { object }: Props = $props();
 async function goToImageBuild(): Promise<void> {
   await gotoImageBuild(object.name, object.tag);
 }
+
+async function deleteImage(): Promise<void> {
+  object.status = 'deleting';
+  await bootcClient.deleteImage(object.engineId, object.id);
+}
 </script>
 
 <ListItemButtonIcon title="Build Disk Image" onClick={goToImageBuild} icon={faBuilding} />
+
+<ListItemButtonIcon title="Delete Image" enabled={object.status === 'unused'} onClick={deleteImage} icon={faTrash} />

--- a/packages/frontend/src/lib/images/ImagesList.spec.ts
+++ b/packages/frontend/src/lib/images/ImagesList.spec.ts
@@ -31,6 +31,7 @@ vi.mock('/@/api/client', async () => {
     bootcClient: {
       listBootcImages: vi.fn(),
       listContainers: vi.fn(),
+      deleteImage: vi.fn(),
     },
     rpcBrowser: {
       subscribe: (): Subscriber => {


### PR DESCRIPTION
### What does this PR do?

Adds the ability to delete images either by selecting images in the list and using the bulk button, or a delete action on every image.

No bulk confirmation for now; not sure it is worth the configuration option and code.

### Screenshot / video of UI

<img width="762" alt="Screenshot 2025-04-11 at 10 12 00 AM" src="https://github.com/user-attachments/assets/3f4269c6-74fa-4883-95b0-2b93d467ed99" />

### What issues does this PR fix or reference?

Final part of #862.

### How to test this PR?

Pull a few images, delete via multi-selection or individual action.