### PR TITLE
fix: no timeout for user interaction

### DIFF
--- a/packages/shared/src/messages/NoTimeoutChannels.ts
+++ b/packages/shared/src/messages/NoTimeoutChannels.ts
@@ -18,4 +18,10 @@
 import { BootcApi } from '../BootcAPI';
 import { getChannel } from './utils';
 
-export const noTimeoutChannels: string[] = [getChannel(BootcApi, 'launchVM'), getChannel(BootcApi, 'pullImage')];
+export const noTimeoutChannels: string[] = [
+  getChannel(BootcApi, 'launchVM'),
+  getChannel(BootcApi, 'pullImage'),
+  getChannel(BootcApi, 'selectOutputFolder'),
+  getChannel(BootcApi, 'selectBuildConfigFile'),
+  getChannel(BootcApi, 'selectAnacondaKickstartFile'),
+];


### PR DESCRIPTION
### What does this PR do?

Calls to the backend that involve user interaction (e.g. picking a folder) could be indefinite and should be excluded from timeouts.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes #1542.

### How to test this PR?

Open the Build page and click the browse button. Wait more than 5s to pick one and confirm it still works.