### PR TITLE
chore: update build page unused div

### DIFF
--- a/packages/frontend/src/Build.svelte
+++ b/packages/frontend/src/Build.svelte
@@ -624,7 +624,7 @@ $: if (availableArchitectures) {
               </p>
             {/if}
           </div>
-          <div>
+          <div class="mb-2">
             <label for="path" class="block mb-2 font-semibold">Output folder</label>
             <div class="flex flex-row space-x-3">
               <Input
@@ -637,7 +637,6 @@ $: if (availableArchitectures) {
               <Button on:click={(): Promise<void> => getPath()}>Browse...</Button>
             </div>
           </div>
-          <div class="pt-3 space-y-3 h-fit">
             <div class="mb-2">
               <span class="text-md font-semibold mb-2 block">Disk image type</span>
               <div class="grid grid-cols-2 gap-8">
@@ -1075,7 +1074,6 @@ $: if (availableArchitectures) {
                   </p>
                 </div>
               </Expandable>
-            </div>
           </div>
         </div>
         {#if existingBuild}


### PR DESCRIPTION
### What does this PR do?

I noticed this when implementing a new page, our Build svelte page has some of the inputs in a separate div that doesn't do anything.  I incorrectly placed a bunch of these elements in the div.  Removing the div should not have any effect on the UI/UX.

### Screenshot / video of UI

![Screenshot 2025-04-24 at 4 03 12 PM](https://github.com/user-attachments/assets/c135a12a-4e99-474e-8b38-f11bcd977988)

No changes above.

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop repository (or from another issue tracker). -->

N/A, chore.

### How to test this PR?

See build page is fine before and after.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>