### PR TITLE
chore: fix spacing in build page.

### DIFF
--- a/packages/frontend/src/Build.svelte
+++ b/packages/frontend/src/Build.svelte
@@ -624,7 +624,7 @@ $: if (availableArchitectures) {
               </p>
             {/if}
           </div>
-          <div class="mb-2">
+          <div class="mb-3">
             <label for="path" class="block mb-2 font-semibold">Output folder</label>
             <div class="flex flex-row space-x-3">
               <Input
@@ -637,7 +637,7 @@ $: if (availableArchitectures) {
               <Button on:click={(): Promise<void> => getPath()}>Browse...</Button>
             </div>
           </div>
-            <div class="mb-2">
+            <div class="mb-3">
               <span class="text-md font-semibold mb-2 block">Disk image type</span>
               <div class="grid grid-cols-2 gap-8">
                 <div class="flex flex-col ml-1 space-y-2">
@@ -688,7 +688,7 @@ $: if (availableArchitectures) {
                 </div>
               </div>
             </div>
-            <div>
+            <div class="mb-3">
               <span class="font-semibold mb-2 block">Filesystem</span>
               <div class="flex items-center mb-3 space-x-3">
                 <label for="defaultFs" class="ml-1 flex items-center cursor-pointer" aria-label="default-radio">
@@ -758,7 +758,7 @@ $: if (availableArchitectures) {
                 {/if}
               </p>
             </div>
-            <div class="mb-2">
+            <div class="mb-3">
               <span class="font-semibold mb-2 block">Platform</span>
               <ul class="grid grid-cols-2 gap-x-2 max-w-md">
                 <li>


### PR DESCRIPTION
chore: fix spacing in build page.

### What does this PR do?

Adds `mb-3` to the sections to add more spacing between sections.

Removing the class from the PR:
https://github.com/podman-desktop/extension-bootc/pull/1573 caused the
spacing to revert back to being close-together.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

Before:

![Screenshot 2025-04-30 at 4 14 45 PM](https://github.com/user-attachments/assets/a1512d6d-7cc3-426b-b37b-2ece471d0ba3)


After:

![Screenshot 2025-04-30 at 4 24 07 PM](https://github.com/user-attachments/assets/3f6f9bcd-a3c3-4050-a3ee-b1575ccb9467)


### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

N/A, no issue.

### How to test this PR?

<!-- Please explain steps to reproduce -->

Just view the build page :)

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
