### PR TITLE
feat: add backend support for Macadam create image

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,8 +70,7 @@
     "typescript": "5.8.3",
     "typescript-eslint": "^8.31.1",
     "vite": "6.3.4",
-    "vitest": "^3.1.2",
-    "globals": "^16.0.0"
+    "vitest": "^3.1.2"
   },
   "dependencies": {
     "@xterm/addon-attach": "^0.11.0",

--- a/packages/backend/__mocks__/@podman-desktop/api.js
+++ b/packages/backend/__mocks__/@podman-desktop/api.js
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024-2025 Red Hat, Inc.
+ * Copyright (C) 2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,10 +15,4 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
-
-// Image related
-export const bootcImageBuilder = 'bootc-image-builder';
-export const bootcImageBuilderCentos =
-  'quay.io/centos-bootc/bootc-image-builder:sha256-e53a3916cfc416f00a54a93757d7a48beb1af7fce3a3a329d07a0eea2e2b0737';
-export const bootcImageBuilderRHEL = 'registry.redhat.io/rhel9/bootc-image-builder:9.5';
-export const macadamName = 'rhel';
+export {};

--- a/packages/backend/src/build-disk-image.spec.ts
+++ b/packages/backend/src/build-disk-image.spec.ts
@@ -72,6 +72,17 @@ vi.mock('./container-utils');
 
 vi.mock('./machine-utils');
 
+vi.mock('@crc-org/macadam.js', () => {
+  const mockInstance = {
+    init: vi.fn(),
+    createVm: vi.fn(),
+    listVms: vi.fn(),
+  };
+  return {
+    Macadam: vi.fn(() => mockInstance),
+  };
+});
+
 beforeEach(() => {
   vi.resetAllMocks();
 });

--- a/packages/backend/src/extension.spec.ts
+++ b/packages/backend/src/extension.spec.ts
@@ -86,6 +86,17 @@ vi.mock('../package.json', () => ({
   },
 }));
 
+vi.mock('@crc-org/macadam.js', () => {
+  const mockInstance = {
+    init: vi.fn(),
+    createVm: vi.fn(),
+    listVms: vi.fn(),
+  };
+  return {
+    Macadam: vi.fn(() => mockInstance),
+  };
+});
+
 beforeEach(() => {
   vi.clearAllMocks();
   console.log = mocks.consoleLogMock;

--- a/packages/backend/src/macadam.spec.ts
+++ b/packages/backend/src/macadam.spec.ts
@@ -1,0 +1,65 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import type { Mock } from 'vitest';
+import { beforeEach, expect, test, vi } from 'vitest';
+import { MacadamHandler } from './macadam';
+import * as macadam from '@crc-org/macadam.js';
+
+vi.mock('@crc-org/macadam.js', () => {
+  const mockInstance = {
+    init: vi.fn(),
+    createVm: vi.fn(),
+    listVms: vi.fn(),
+  };
+  return {
+    Macadam: vi.fn(() => mockInstance),
+  };
+});
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+test('Test creating VM with MacadamHandler', async () => {
+  const macadamVm = new MacadamHandler(); // This must come first
+  const macadamInstance = (macadam.Macadam as Mock).mock.results[0].value;
+  macadamInstance.createVm.mockResolvedValue({ stdout: '', stderr: '' });
+
+  await macadamVm.createVm({
+    name: 'foobar',
+    imagePath: '~/test-image.qcow2',
+    sshIdentityPath: '~/test-ssh-key',
+  });
+
+  expect(macadamInstance.createVm).toHaveBeenCalled();
+
+  const callOptions = macadamInstance.createVm.mock.calls[0][0];
+  expect(callOptions.imagePath).not.toContain('~/');
+  expect(callOptions.sshIdentityPath).not.toContain('~/');
+});
+
+test('Test listing VMs with MacadamHandler', async () => {
+  const macadamVm = new MacadamHandler(); // This must come first
+  const macadamInstance = (macadam.Macadam as Mock).mock.results[0].value;
+  macadamInstance.listVms.mockResolvedValue([{ name: 'test-vm' }]);
+
+  const vms = await macadamVm.listVms();
+
+  expect(macadamInstance.listVms).toHaveBeenCalled();
+  expect(vms).toEqual([{ name: 'test-vm' }]);
+});

--- a/packages/backend/src/macadam.ts
+++ b/packages/backend/src/macadam.ts
@@ -1,0 +1,71 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import * as macadam from '@crc-org/macadam.js';
+import { macadamName } from './constants';
+
+interface StderrError extends Error {
+  stderr?: string;
+}
+export class MacadamHandler {
+  private macadam: macadam.Macadam;
+
+  constructor() {
+    // IMPORTANT NOTE
+    // In order for this to work with the RHEL VM extension, you must use 'rhel' as the macadam name.
+    // This is the given "type" and will only appear within Settings > Resources if it's prefixed with rhel.
+    this.macadam = new macadam.Macadam(macadamName);
+  }
+
+  async createVm(options: macadam.CreateVmOptions): Promise<void> {
+    try {
+      // Before going forward, make sure that the path names for both imagePath and sshIdentityPath are the full
+      // paths (not using ~/). This is important since the macadam library does not handle this case.
+      if (options.sshIdentityPath) {
+        options.sshIdentityPath = options.sshIdentityPath.replace(/^~\//, `${process.env.HOME}/`);
+      }
+      options.imagePath = options.imagePath.replace(/^~\//, `${process.env.HOME}/`);
+
+      await this.macadam.init();
+      await this.macadam.createVm(options);
+    } catch (e) {
+      // Use this below since createVm returns stderr in the error object as well. This comes in handy when
+      // the VM creation fails due to a missing image or other issues.
+      let errorMessage: string;
+      if (e instanceof Error) {
+        const stderrError = e as StderrError;
+        errorMessage = `${stderrError.message} ${stderrError.stderr ?? ''}`;
+      } else {
+        errorMessage = String(e);
+      }
+      console.error('Failed to create VM:', errorMessage);
+      throw new Error(`VM creation failed: ${errorMessage}`);
+    }
+  }
+
+  // List all virtual machines.
+  async listVms(): Promise<macadam.VmDetails[]> {
+    try {
+      await this.macadam.init();
+      const vms = await this.macadam.listVms({});
+      return vms;
+    } catch (err) {
+      console.error('Failed to list VMs:', err);
+      throw new Error(`VM listing failed: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+}

--- a/packages/shared/src/BootcAPI.ts
+++ b/packages/shared/src/BootcAPI.ts
@@ -19,12 +19,15 @@
 import type { BootcBuildInfo, BuildType } from './models/bootc';
 import type { ImageInfo, ImageInspectInfo, ManifestInspectInfo, ContainerInfo } from '@podman-desktop/api';
 import type { ExamplesList } from './models/examples';
+import type { CreateVmOptions, VmDetails } from '@crc-org/macadam.js';
 
 export abstract class BootcApi {
   static readonly CHANNEL: string = 'BootcApi';
   abstract checkPrereqs(): Promise<string | undefined>;
   abstract checkVMLaunchPrereqs(buildId: string): Promise<string | undefined>;
   abstract launchVM(buildId: string): Promise<void>;
+  abstract createVM(options: CreateVmOptions): Promise<void>;
+  abstract listVMs(): Promise<VmDetails[]>;
   abstract buildExists(folder: string, types: BuildType[]): Promise<boolean>;
   abstract buildImage(build: BootcBuildInfo, overwrite?: boolean): Promise<void>;
   abstract pullImage(image: string, arch?: string): Promise<void>;
@@ -33,6 +36,8 @@ export abstract class BootcApi {
   abstract deleteBuilds(buildIds: string[]): Promise<void>;
   abstract selectOutputFolder(): Promise<string>;
   abstract selectBuildConfigFile(): Promise<string>;
+  abstract selectVMImageFile(): Promise<string>;
+  abstract selectSSHPrivateKeyFile(): Promise<string>;
   abstract selectAnacondaKickstartFile(): Promise<string>;
   abstract listBootcImages(): Promise<ImageInfo[]>;
   abstract listContainers(): Promise<ContainerInfo[]>;

--- a/packages/shared/src/messages/NoTimeoutChannels.ts
+++ b/packages/shared/src/messages/NoTimeoutChannels.ts
@@ -24,4 +24,7 @@ export const noTimeoutChannels: string[] = [
   getChannel(BootcApi, 'selectOutputFolder'),
   getChannel(BootcApi, 'selectBuildConfigFile'),
   getChannel(BootcApi, 'selectAnacondaKickstartFile'),
+  getChannel(BootcApi, 'selectSSHPrivateKeyFile'),
+  getChannel(BootcApi, 'selectVMImageFile'),
+  getChannel(BootcApi, 'createVM'),
 ];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,9 +83,6 @@ importers:
       eslint-plugin-unicorn:
         specifier: ^59.0.0
         version: 59.0.0(eslint@9.22.0(jiti@2.4.2))
-      globals:
-        specifier: ^16.0.0
-        version: 16.0.0
       husky:
         specifier: ^9.1.7
         version: 9.1.7


### PR DESCRIPTION
feat: add backend support for Macadam create image

### What does this PR do?

* Adds Macadam create image backend support
* Adds unit tests and constants updates

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Reference: https://github.com/podman-desktop/extension-bootc/issues/1521

### How to test this PR?

1. Run backend unit tests
2. Test API integration with frontend.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
