### PR TITLE
feat: add Macadam create image UI

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -17,6 +17,7 @@
     "watch": "vite --mode development build -w"
   },
   "dependencies": {
+    "@crc-org/macadam.js": "0.0.1-202504301306-5ade487",
     "svelte-check": "^4.1.6",
     "svelte-preprocess": "^6.0.3",
     "tinro": "^0.6.12"

--- a/packages/frontend/src/App.svelte
+++ b/packages/frontend/src/App.svelte
@@ -14,6 +14,7 @@ import DiskImagesList from './lib/disk-image/DiskImagesList.svelte';
 import Dashboard from './lib/dashboard/Dashboard.svelte';
 import ExampleDetails from './lib/examples/ExampleDetails.svelte';
 import ImagesList from './lib/images/ImagesList.svelte';
+import CreateVM from './CreateVM.svelte';
 
 router.mode.hash();
 
@@ -61,6 +62,9 @@ onMount(() => {
       </Route>
       <Route path="/disk-images/build/:name/:tag" breadcrumb="Build" let:meta>
         <Build imageName={decodeURIComponent(meta.params.name)} imageTag={decodeURIComponent(meta.params.tag)} />
+      </Route>
+      <Route path="/disk-images/createVM/:imageName/:imagePath" breadcrumb="Create Virtual Machine" let:meta>
+        <CreateVM imageName={atob(meta.params.imageName)} imagePath={atob(meta.params.imagePath)} />
       </Route>
     </div>
   </main>

--- a/packages/frontend/src/CreateVM.svelte
+++ b/packages/frontend/src/CreateVM.svelte
@@ -1,0 +1,228 @@
+<script lang="ts">
+import { onMount } from 'svelte';
+import { Button, EmptyScreen, ErrorMessage, FormPage, Input } from '@podman-desktop/ui-svelte';
+import Link from './lib/Link.svelte';
+import { faCheck, faTriangleExclamation } from '@fortawesome/free-solid-svg-icons';
+import { goToDiskImages } from './lib/navigation';
+import { cleanup } from '@testing-library/svelte';
+import DiskImageIcon from './lib/DiskImageIcon.svelte';
+import { bootcClient } from './api/client';
+import type { VmDetails } from '@crc-org/macadam.js';
+
+interface Props {
+  imageName: string;
+  imagePath: string;
+}
+let { imageName, imagePath }: Props = $props();
+
+// Variables
+let errorFormValidation = $state('');
+let createInProgress = $state(false);
+let createErrorMessage = $state('');
+let createSuccessMessage = $state('');
+let sshPrivateKeyLocation = $state('');
+let sshUsername = $state('');
+let virtualMachineName = $state('');
+
+// An array of strings to store the list of VM names to be used for validation
+let existingVMNames = $state<string[]>([]);
+
+// Validate imagePath as well as virtualMachineName & existingVMNames. We should prioritize the imagePath first however
+// as it's the most important one. If the imagePath is not valid, we should not even check for the VM name / check list VMs.
+$effect(() => {
+  if (imagePath && !(imagePath.endsWith('.raw') || imagePath.endsWith('.qcow2'))) {
+    errorFormValidation = 'Only raw or qcow2 file formats are supported. Please select a valid image file.';
+  } else if (virtualMachineName && existingVMNames.includes(virtualMachineName)) {
+    errorFormValidation =
+      'The virtual machine name already exists. Please choose a different name or delete the existing virtual machine under Settings > Resources.';
+  } else {
+    errorFormValidation = '';
+  }
+});
+
+onMount(async () => {
+  // If the image name is not empty, set the default name for the virtual machine
+  virtualMachineName = imageName ? getDefaultNameFromImageName(imageName) : '';
+
+  // On mount, we will get the "default" configuration values for the username as well as ssh private key location
+  // and propagate them to the ssh input fields.
+  await getDefaultConfigurationSettings();
+
+  // Get the list of virtual machines and store them in a variable on load,
+  // so we can use them to check if the user is trying to create a VM with the same name as an existing one.
+  existingVMNames = await listNamesOfVms();
+});
+
+// Take the name of the image, for example: quay.io/foobar/image:latest
+// and return just "image". This will be used to set a "default name" for the virtual machine name
+// based on what's in the image name.
+function getDefaultNameFromImageName(imageName: string): string {
+  const imageParts = imageName.split('/');
+  const imageTag = imageParts[imageParts.length - 1];
+  const imageNameWithoutTag = imageTag.split(':')[0];
+  return imageNameWithoutTag;
+}
+
+async function getDefaultConfigurationSettings(): Promise<void> {
+  try {
+    sshPrivateKeyLocation = (await bootcClient.getConfigurationValue('bootc', 'macadam.ssh.private.key')) as string;
+    sshUsername = (await bootcClient.getConfigurationValue('bootc', 'macadam.ssh.username')) as string;
+  } catch (error) {
+    console.error('Error getting default configuration settings:', error);
+  }
+}
+
+async function getVMImageFile(): Promise<void> {
+  imagePath = await bootcClient.selectVMImageFile();
+}
+
+async function getSSHPrivateKeyFile(): Promise<void> {
+  sshPrivateKeyLocation = await bootcClient.selectSSHPrivateKeyFile();
+}
+
+// Function that lists all the virtual machines from macadam for us to parse / check
+// so we can show a message if the user tries to create a VM with the same name as an existing one.
+async function listNamesOfVms(): Promise<string[]> {
+  try {
+    const vms = await bootcClient.listVMs();
+
+    // Returns the list of VM names, as we do not need any other details from the VM
+    const vmNames = vms.map((vm: VmDetails) => vm.Name);
+    return vmNames;
+  } catch (error) {
+    console.error('Error listing VMs:', error);
+    return []; // Return an empty array in case of an error
+  }
+}
+
+async function createVM(): Promise<void> {
+  createInProgress = true;
+  createErrorMessage = '';
+  try {
+    await bootcClient.createVM({
+      imagePath,
+      name: virtualMachineName,
+      username: sshUsername,
+      sshIdentityPath: sshPrivateKeyLocation,
+    });
+    createSuccessMessage = 'Virtual machine created successfully.';
+  } catch (error) {
+    createErrorMessage = 'An error occurred while creating the virtual machine. Error: ' + error;
+  } finally {
+    createInProgress = false;
+  }
+}
+</script>
+
+<FormPage
+  title="Create Virtual Machine"
+  inProgress={createInProgress}
+  breadcrumbLeftPart="Disk Images"
+  breadcrumbRightPart="Create Virtual Machine"
+  breadcrumbTitle="Go back to disk images"
+  onclose={goToDiskImages}
+  onbreadcrumbClick={goToDiskImages}>
+  <DiskImageIcon slot="icon" size="30px" />
+
+  <div slot="content" class="p-5 min-w-full h-fit">
+    {#if createErrorMessage}
+      <EmptyScreen
+        icon={faTriangleExclamation}
+        title="Error with virtual machine creation"
+        message={createErrorMessage}>
+        <Button
+          class="py-3"
+          on:click={(): void => {
+            cleanup();
+            goToDiskImages();
+          }}>
+          Go back
+        </Button>
+      </EmptyScreen>
+    {:else if createSuccessMessage}
+      <EmptyScreen icon={faCheck} title="Virtual machine created" message={createSuccessMessage}>
+        <p class="text-md text-[var(--pd-content-text)] pb-2 ">
+          In order to use the virtual machine, you must install the <Link
+            externalRef="https://github.com/redhat-developer/podman-desktop-rhel-ext">Macadam extension</Link>.<br/>Afterwards, you can find your virtual machine under <strong>Settings > Resources</strong>.
+        </p>
+        <Button
+          class="py-3"
+          on:click={(): void => {
+            cleanup();
+            goToDiskImages();
+          }}>
+          Go back
+        </Button>
+      </EmptyScreen>
+    {:else}
+      <div
+        class="bg-[var(--pd-content-card-bg)] pt-5 space-y-6 px-8 sm:pb-6 xl:pb-8 rounded-lg text-[var(--pd-content-card-header-text)]">
+        <div class={createInProgress ? 'opacity-40 pointer-events-none' : ''}>
+          <div class="pb-4">
+            <p class="text-sm text-[var(--pd-content-text)]">
+              Virtual machines are created using the <Link externalRef="https://github.com/crc-org/macadam"
+                >Macadam</Link> tool. This is a cross-platform tool to create and manage virtual machines. The following
+              form will help you create a virtual machine by specifying the image file location and SSH credentials.<br /><br />
+              <strong>Requirement:</strong> In order to access and manage the virtual machine, you must install the <Link
+                externalRef="https://github.com/redhat-developer/podman-desktop-rhel-ext">Macadam extension</Link
+              >.<br /><br />
+              <strong>Note:</strong> You must have added a valid public SSH key during the build process to be able to connect to
+              the VM using the credentials below.
+            </p>
+          </div>
+          <div class="pb-4">
+            <label for="vm-name" class="block mb-2 font-semibold">Name</label>
+            <Input
+              name="vm-name"
+              id="vm-name"
+              bind:value={virtualMachineName}
+              placeholder="Name for your virtual machine"
+              class="w-full"
+              aria-label="vm-name" />
+          </div>
+          <div class="pb-4">
+            <label for="path" class="block mb-2 font-semibold">Image file location (*.raw or *.qcow2)</label>
+            <div class="flex flex-row space-x-3">
+              <Input
+                name="path"
+                id="path"
+                bind:value={imagePath}
+                placeholder="Output folder"
+                class="w-full"
+                aria-label="folder-select" />
+              <Button on:click={(): Promise<void> => getVMImageFile()}>Browse...</Button>
+            </div>
+          </div>
+          <div class="pb-4">
+            <label for="ssh-username" class="block mb-2 font-semibold">Username (ex. root)</label>
+            <Input
+              name="ssh-username"
+              id="ssh-username"
+              bind:value={sshUsername}
+              placeholder="SSH username"
+              class="w-full"
+              aria-label="ssh-username" />
+          </div>
+          <div class="pb-4">
+            <label for="ssh-private-key" class="block mb-2 font-semibold">SSH private key filepath (ex. ~/.ssh/id_rsa)</label>
+            <div class="flex flex-row space-x-3">
+              <Input
+                name="ssh-private-key"
+                id="ssh-private-key"
+                bind:value={sshPrivateKeyLocation}
+                placeholder="SSH private key location"
+                class="w-full"
+                aria-label="ssh-private-key" />
+              <Button on:click={(): Promise<void> => getSSHPrivateKeyFile()}>Browse...</Button>
+            </div>
+          </div>
+        </div>
+        {#if errorFormValidation !== ''}
+          <ErrorMessage aria-label="validation" error={errorFormValidation} />
+        {/if}
+        <Button class="w-full" on:click={createVM} disabled={errorFormValidation !== '' || createInProgress}
+          >Create Virtual Machine</Button>
+      </div>
+    {/if}
+  </div>
+</FormPage>

--- a/packages/frontend/src/lib/disk-image/DiskImageActions.spec.ts
+++ b/packages/frontend/src/lib/disk-image/DiskImageActions.spec.ts
@@ -27,6 +27,8 @@ vi.mock('/@/api/client', async () => {
     bootcClient: {
       deleteBuilds: vi.fn(),
       isWindows: vi.fn(),
+      isMac: vi.fn(),
+      isLinux: vi.fn(),
     },
     rpcBrowser: {
       subscribe: (): Subscriber => {

--- a/packages/frontend/src/lib/disk-image/DiskImageActions.svelte
+++ b/packages/frontend/src/lib/disk-image/DiskImageActions.svelte
@@ -12,7 +12,8 @@ interface Props {
 }
 
 let { object, detailed = false }: Props = $props();
-let isWindows = $state(false);
+let isLinux = $state(false);
+let isMac = $state(false);
 
 // Delete the build
 async function deleteBuild(): Promise<void> {
@@ -28,17 +29,26 @@ async function gotoVM(): Promise<void> {
   router.goto(`/disk-image/${btoa(object.id)}/vm`);
 }
 
+async function initMacadamVM(): Promise<void> {
+  // We must pass in the full path to the disk image, so we combine object.folder as well as 'image/disk.raw'.
+  const imagePath = object.folder + '/image/disk.raw';
+  router.goto(`/disk-images/createVM/${btoa(object.image)}/${btoa(imagePath)}`);
+}
+
 onMount(async () => {
-  isWindows = await bootcClient.isWindows();
+  isLinux = await bootcClient.isLinux();
+  isMac = await bootcClient.isMac();
 });
 </script>
 
 {#if !detailed}
-  <!-- Only show the Terminal button if object.arch actually exists or else we will not be able to pass in the architecture information to the build correctly.
-  Only show if on macOS as well as that is the only option we support at the moment -->
-  {#if object.arch && !isWindows}
+  <!-- Only show if Linux, as Macadam Linux isn't supported yet: -->
+  {#if object.arch && isLinux}
     <ListItemButtonIcon title="Launch VM" onClick={gotoVM} detailed={detailed} icon={faTerminal} />
+  {:else if object.arch && isMac}
+    <ListItemButtonIcon title="Create VM" onClick={initMacadamVM} detailed={detailed} icon={faTerminal} />
   {/if}
   <ListItemButtonIcon title="Build Logs" onClick={gotoLogs} detailed={detailed} icon={faFileAlt} />
 {/if}
+
 <ListItemButtonIcon title="Delete Build" onClick={deleteBuild} detailed={detailed} icon={faTrash} />

--- a/packages/frontend/src/lib/disk-image/DiskImageDetails.spec.ts
+++ b/packages/frontend/src/lib/disk-image/DiskImageDetails.spec.ts
@@ -23,7 +23,6 @@ import { bootcClient } from '/@/api/client';
 
 import DiskImageDetails from './DiskImageDetails.svelte';
 import type { BootcBuildInfo } from '/@shared/src/models/bootc';
-import { tick } from 'svelte';
 import type { Subscriber } from '/@shared/src/messages/MessageProxy';
 
 const image: BootcBuildInfo = {
@@ -41,6 +40,8 @@ vi.mock('/@/api/client', async () => {
     bootcClient: {
       listHistoryInfo: vi.fn(),
       isWindows: vi.fn(),
+      isMac: vi.fn(),
+      isLinux: vi.fn(),
     },
     rpcBrowser: {
       subscribe: (): Subscriber => {
@@ -58,12 +59,12 @@ beforeEach(() => {
 
 test('Confirm renders disk image details', async () => {
   vi.mocked(bootcClient.listHistoryInfo).mockResolvedValue([image]);
-  vi.mocked(bootcClient.isWindows).mockResolvedValue(false);
+  vi.mocked(bootcClient.isMac).mockResolvedValue(true);
 
   render(DiskImageDetails, { id: btoa(image.id) });
 
   // allow UI time to update
-  await tick();
-
-  expect(screen.getByText(image.image + ':' + image.tag)).toBeInTheDocument();
+  await vi.waitFor(() => {
+    expect(screen.getByText(image.image + ':' + image.tag)).toBeInTheDocument();
+  });
 });

--- a/packages/frontend/src/lib/disk-image/DiskImageDetails.svelte
+++ b/packages/frontend/src/lib/disk-image/DiskImageDetails.svelte
@@ -23,11 +23,12 @@ let { id }: Props = $props();
 let diskImage = $state<BootcBuildInfo>();
 let detailsPage = $state<DetailsPage>();
 let historyInfoUnsubscribe = $state<Unsubscriber>();
-let isWindows = $state(false);
+let isMac = $state(false);
+let isLinux = $state(false);
 
 onMount(async () => {
-  // See if we are on mac or linux or not for the VM tab
-  isWindows = await bootcClient.isWindows();
+  isMac = await bootcClient.isMac();
+  isLinux = await bootcClient.isLinux();
 
   // Subscribe to the history to update the details page
   const actualId = atob(id);
@@ -70,7 +71,8 @@ onDestroy(() => {
   <svelte:fragment slot="tabs">
     <Tab title="Summary" selected={isTabSelected($router.path, 'summary')} url={getTabUrl($router.path, 'summary')} />
     <Tab title="Build Log" selected={isTabSelected($router.path, 'build')} url={getTabUrl($router.path, 'build')} />
-    {#if !isWindows}
+    <!-- Our "experimental" support is only supported on Linux now, as we have the Macadam button for macOS. -->
+    {#if isLinux}
       <Tab
         title="Virtual Machine (Experimental)"
         selected={isTabSelected($router.path, 'vm')}

--- a/packages/frontend/src/lib/disk-image/DiskImagesList.spec.ts
+++ b/packages/frontend/src/lib/disk-image/DiskImagesList.spec.ts
@@ -55,6 +55,7 @@ vi.mock('/@/api/client', async () => {
       telemetryLogUsage: vi.fn(),
       isMac: vi.fn(),
       isWindows: vi.fn(),
+      isLinux: vi.fn(),
     },
     rpcBrowser: {
       subscribe: (): Subscriber => {

--- a/packages/frontend/src/lib/disk-image/columns/Actions.spec.ts
+++ b/packages/frontend/src/lib/disk-image/columns/Actions.spec.ts
@@ -37,6 +37,7 @@ vi.mock('/@/api/client', async () => {
     bootcClient: {
       isMac: vi.fn(),
       isWindows: vi.fn(),
+      isLinux: vi.fn(),
     },
     rpcBrowser: {
       subscribe: (): Subscriber => {

--- a/packages/shared/src/messages/NoTimeoutChannels.ts
+++ b/packages/shared/src/messages/NoTimeoutChannels.ts
@@ -27,4 +27,5 @@ export const noTimeoutChannels: string[] = [
   getChannel(BootcApi, 'selectSSHPrivateKeyFile'),
   getChannel(BootcApi, 'selectVMImageFile'),
   getChannel(BootcApi, 'createVM'),
+  getChannel(BootcApi, 'listVMs'),
 ];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -186,6 +186,9 @@ importers:
 
   packages/frontend:
     dependencies:
+      '@crc-org/macadam.js':
+        specifier: 0.0.1-202504301306-5ade487
+        version: 0.0.1-202504301306-5ade487
       svelte-check:
         specifier: ^4.1.6
         version: 4.1.6(picomatch@4.0.2)(svelte@5.23.2)(typescript@5.8.3)
@@ -3942,8 +3945,7 @@ snapshots:
 
   '@babel/helper-validator-identifier@7.25.9': {}
 
-  '@babel/helper-validator-identifier@7.27.1':
-    optional: true
+  '@babel/helper-validator-identifier@7.27.1': {}
 
   '@babel/helper-validator-option@7.27.1':
     optional: true
@@ -5707,7 +5709,7 @@ snapshots:
 
   eslint-plugin-unicorn@59.0.0(eslint@9.22.0(jiti@2.4.2)):
     dependencies:
-      '@babel/helper-validator-identifier': 7.25.9
+      '@babel/helper-validator-identifier': 7.27.1
       '@eslint-community/eslint-utils': 4.6.1(eslint@9.22.0(jiti@2.4.2))
       '@eslint/plugin-kit': 0.2.8
       ci-info: 4.2.0


### PR DESCRIPTION
feat: add Macadam create image UI

### What does this PR do?

* Removes the experimental VM tab for macOS
* Replaces the VM button with Macadam support
* Adds new Macadam create image screen

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Closes https://github.com/podman-desktop/extension-bootc/issues/1521
Closes https://github.com/podman-desktop/extension-bootc/issues/1520
Closes https://github.com/podman-desktop/extension-bootc/issues/876

### How to test this PR?

1. Create a GitHub token (legacy permission token) with read:packages permission
2. Create '.npmrc' in the root folder with the token
3. Run 'pnpm install'
4. Run 'pnpm watch'
5. Launch in Podman Desktop ('pnpm watch --extension-folder ../bootc/packages/backend/media')
6. Build an image in the bootc extension
7. Press the VM button and confirm creation succeeds.
