### PR TITLE
chore: add create vm form to navigation api

### DIFF
--- a/packages/frontend/src/lib/disk-image/DiskImageActions.svelte
+++ b/packages/frontend/src/lib/disk-image/DiskImageActions.svelte
@@ -5,6 +5,7 @@ import { faFileAlt, faTrash, faTerminal } from '@fortawesome/free-solid-svg-icon
 import { router } from 'tinro';
 import { bootcClient } from '/@/api/client';
 import { onMount } from 'svelte';
+import { gotoCreateVM } from '../navigation';
 
 interface Props {
   object: BootcBuildInfo;
@@ -32,7 +33,7 @@ async function gotoVM(): Promise<void> {
 async function initMacadamVM(): Promise<void> {
   // We must pass in the full path to the disk image, so we combine object.folder as well as 'image/disk.raw'.
   const imagePath = object.folder + '/image/disk.raw';
-  router.goto(`/disk-images/createVM/${btoa(object.image)}/${btoa(imagePath)}`);
+  await gotoCreateVM(object.image, imagePath);
 }
 
 onMount(async () => {

--- a/packages/frontend/src/lib/navigation.spec.ts
+++ b/packages/frontend/src/lib/navigation.spec.ts
@@ -1,0 +1,86 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+import { router } from 'tinro';
+
+import { beforeEach, expect, test, vi } from 'vitest';
+import { gotoBuild, gotoCreateVM, gotoCreateVMForm, goToDiskImages, gotoImageBuild } from './navigation';
+import { bootcClient } from '../api/client';
+import type { Subscriber } from '/@shared/src/messages/MessageProxy';
+
+vi.mock('/@/api/client', async () => {
+  return {
+    bootcClient: {
+      telemetryLogUsage: vi.fn(),
+    },
+    rpcBrowser: {
+      subscribe: (): Subscriber => {
+        return {
+          unsubscribe: (): void => {},
+        };
+      },
+    },
+  };
+});
+
+vi.mock('tinro', () => {
+  return {
+    router: {
+      goto: vi.fn(),
+    },
+  };
+});
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+test('Test goToDiskImages navigation', async () => {
+  goToDiskImages();
+
+  expect(router.goto).toHaveBeenCalledWith('/disk-images');
+});
+
+test('Test gotoBuild navigation', async () => {
+  await gotoBuild();
+
+  expect(router.goto).toHaveBeenCalledWith('/disk-images/build');
+  expect(bootcClient.telemetryLogUsage).toHaveBeenCalledWith('nav-build');
+});
+
+test('Test gotoImageBuild navigation', async () => {
+  await gotoImageBuild('name', 'tag');
+
+  expect(router.goto).toHaveBeenCalledWith('/disk-images/build/name/tag');
+  expect(bootcClient.telemetryLogUsage).toHaveBeenCalledWith('nav-build');
+});
+
+test('Test gotoCreateVMForm navigation', async () => {
+  await gotoCreateVMForm();
+
+  expect(router.goto).toHaveBeenCalledWith('/disk-images/createVM');
+  expect(bootcClient.telemetryLogUsage).toHaveBeenCalledWith('nav-create-vm');
+});
+
+test('Test gotoCreateVM navigation', async () => {
+  await gotoCreateVM('image', 'path');
+
+  expect(router.goto).toHaveBeenCalledWith('/disk-images/createVM/aW1hZ2U=/cGF0aA==');
+  expect(bootcClient.telemetryLogUsage).toHaveBeenCalledWith('nav-create-vm');
+});

--- a/packages/frontend/src/lib/navigation.ts
+++ b/packages/frontend/src/lib/navigation.ts
@@ -31,3 +31,13 @@ export async function gotoImageBuild(name: string, tag: string): Promise<void> {
   await bootcClient.telemetryLogUsage('nav-build');
   router.goto(`/disk-images/build/${encodeURIComponent(name)}/${encodeURIComponent(tag)}`);
 }
+
+export async function gotoCreateVMForm(): Promise<void> {
+  await bootcClient.telemetryLogUsage('nav-create-vm');
+  router.goto('/disk-images/createVM');
+}
+
+export async function gotoCreateVM(image: string, path: string): Promise<void> {
+  await bootcClient.telemetryLogUsage('nav-create-vm');
+  router.goto(`/disk-images/createVM/${btoa(image)}/${btoa(path)}`);
+}


### PR DESCRIPTION
### What does this PR do?

Adds the Create VM form to the navigation api, and uses it in the action on the disk images page. Adds navigation telemetry so we know how often users are going to this page.

Added tests, included missing ones for existing navigation.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Part of #1588.

### How to test this PR?

Confirm navigation still works to create VM form.