### PR TITLE
chore: add create vm button to disk image list

### DIFF
--- a/packages/frontend/src/App.svelte
+++ b/packages/frontend/src/App.svelte
@@ -63,6 +63,9 @@ onMount(() => {
       <Route path="/disk-images/build/:name/:tag" breadcrumb="Build" let:meta>
         <Build imageName={decodeURIComponent(meta.params.name)} imageTag={decodeURIComponent(meta.params.tag)} />
       </Route>
+      <Route path="/disk-images/createVM" breadcrumb="Create Virtual Machine">
+        <CreateVM />
+      </Route>
       <Route path="/disk-images/createVM/:imageName/:imagePath" breadcrumb="Create Virtual Machine" let:meta>
         <CreateVM imageName={atob(meta.params.imageName)} imagePath={atob(meta.params.imagePath)} />
       </Route>

--- a/packages/frontend/src/CreateVM.svelte
+++ b/packages/frontend/src/CreateVM.svelte
@@ -10,8 +10,8 @@ import { bootcClient } from './api/client';
 import type { VmDetails } from '@crc-org/macadam.js';
 
 interface Props {
-  imageName: string;
-  imagePath: string;
+  imageName?: string;
+  imagePath?: string;
 }
 let { imageName, imagePath }: Props = $props();
 
@@ -96,6 +96,10 @@ async function listNamesOfVms(): Promise<string[]> {
 }
 
 async function createVM(): Promise<void> {
+  if (!imagePath) {
+    // can never happen, just for typecheck
+    return;
+  }
   createInProgress = true;
   createErrorMessage = '';
   try {

--- a/packages/frontend/src/lib/disk-image/DiskImagesList.svelte
+++ b/packages/frontend/src/lib/disk-image/DiskImagesList.svelte
@@ -115,8 +115,8 @@ const row = new TableRow<BootcBuildInfo>({
 
 <NavPage bind:searchTerm={searchTerm} title="Disk Images" searchEnabled={true}>
   <svelte:fragment slot="additional-actions">
-    <Button on:click={gotoBuild} icon={DiskImageIcon} title="Build">Build</Button>
     <Button on:click={gotoCreateVMForm} icon={DiskImageIcon} title="Create VM">Create VM</Button>
+    <Button on:click={gotoBuild} icon={DiskImageIcon} title="Build">Build</Button>
   </svelte:fragment>
 
   <svelte:fragment slot="bottom-additional-actions">

--- a/packages/frontend/src/lib/disk-image/DiskImagesList.svelte
+++ b/packages/frontend/src/lib/disk-image/DiskImagesList.svelte
@@ -19,7 +19,7 @@ import {
   FilteredEmptyScreen,
 } from '@podman-desktop/ui-svelte';
 import DiskImageEmptyScreen from './DiskImageEmptyScreen.svelte';
-import { gotoBuild } from '../navigation';
+import { gotoBuild, gotoCreateVMForm } from '../navigation';
 
 interface Props {
   searchTerm?: string;
@@ -116,6 +116,7 @@ const row = new TableRow<BootcBuildInfo>({
 <NavPage bind:searchTerm={searchTerm} title="Disk Images" searchEnabled={true}>
   <svelte:fragment slot="additional-actions">
     <Button on:click={gotoBuild} icon={DiskImageIcon} title="Build">Build</Button>
+    <Button on:click={gotoCreateVMForm} icon={DiskImageIcon} title="Create VM">Create VM</Button>
   </svelte:fragment>
 
   <svelte:fragment slot="bottom-additional-actions">


### PR DESCRIPTION
### What does this PR do?

Adds a Create VM button to the disk image list, matching what we have for building disk images (you can launch on an image to pre-fill the page, or you can just open the build page and select everything).

Since this is the first time the Create VM form is used without input params, the route has to be added and parameters made optional.

### Screenshot / video of UI

![Screenshot 2025-05-02 at 2 55 26 PM](https://github.com/user-attachments/assets/5caa93ed-8de8-40f7-98f4-97b5932dc9d9)

### What issues does this PR fix or reference?

Part of #1588

### How to test this PR?

Open Disk Images page and confirm that the Create VM button is there and opens the form.