### PR TITLE
chore: shorten/simplify vm error messages

### DIFF
--- a/packages/backend/src/api-impl.ts
+++ b/packages/backend/src/api-impl.ts
@@ -75,21 +75,13 @@ export class BootcApiImpl implements BootcApi {
   // Launches a macadam VM by initializing the class and initializing the VM
   async createVM(options: CreateVmOptions): Promise<void> {
     const macadam = new MacadamHandler();
-    try {
-      await macadam.createVm(options);
-    } catch (e) {
-      throw new Error(`Error creating Macadam VM: ${e}`);
-    }
+    await macadam.createVm(options);
   }
 
   // Returns a list of all the VM's currently in use
   async listVMs(): Promise<VmDetails[]> {
     const macadam = new MacadamHandler();
-    try {
-      return await macadam.listVms();
-    } catch (e) {
-      throw new Error(`Error listing Macadam VMs: ${e}`);
-    }
+    return await macadam.listVms();
   }
 
   async launchVM(buildId: string): Promise<void> {

--- a/packages/backend/src/macadam.ts
+++ b/packages/backend/src/macadam.ts
@@ -68,7 +68,7 @@ export class MacadamHandler {
         }
         telemetryData.error = errorMessage;
         console.error('Failed to create VM:', errorMessage);
-        throw new Error(`VM creation failed: ${errorMessage}`);
+        throw new Error(`Error creating VM: ${errorMessage}`);
       })
       .finally(() => {
         telemetryLogger.logUsage('createVM', telemetryData);
@@ -83,7 +83,7 @@ export class MacadamHandler {
       return vms;
     } catch (err) {
       console.error('Failed to list VMs:', err);
-      throw new Error(`VM listing failed: ${err instanceof Error ? err.message : String(err)}`);
+      throw new Error(`Error listing VMs: ${err instanceof Error ? err.message : String(err)}`);
     }
   }
 }


### PR DESCRIPTION
### What does this PR do?

When VM creation fails (usually due to a configuration issue), the error messages are kind of long. macadam.ts is catching the underlying Macadam errors and wrapping them in an error message like:
  'VM creation failed: ${e}' and
  'VM listing failed: ${e}'
Then the try/catch blocks in api-impl were catching and wrapping them a second time, creating:
  'Error creating Macadam VM: VM creation failed: ${e}' and
  'Error listing Macadam VMs: VM listing failed: ${e}'

This removes the wrapping in api-impl and simplifies the error messages to just:
  'Error creating VM: ${e}' and
  'Error listing VMs: ${e}'
to make them shorter and easier to read.

New tests ensure the api-impl just passes through the underlying error message. createAPI() added to reduce copy/paste.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Found while working on #1588.

### How to test this PR?

Use something like an invalid path to get the VM creating to fail, and confirm shorter error message.