### PR TITLE
feat: bootc vm provider

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -107,6 +107,7 @@
     "@types/node": "^22",
     "@typescript-eslint/eslint-plugin": "^8.32.0",
     "@typescript-eslint/parser": "^8.32.0",
+    "@types/ssh2": "^1.15.5",
     "@vitest/coverage-v8": "^3.1.2",
     "@xterm/addon-attach": "^0.11.0",
     "@xterm/addon-fit": "^0.10.0",
@@ -126,6 +127,8 @@
   },
   "dependencies": {
     "@crc-org/macadam.js": "0.0.1-202505091153-d597ec3",
-    "semver": "^7.7.2"
+    "semver": "^7.7.2",
+    "compare-versions": "^6.1.1",
+    "ssh2": "^1.16.0"
   }
 }

--- a/packages/backend/src/extension.spec.ts
+++ b/packages/backend/src/extension.spec.ts
@@ -77,6 +77,12 @@ vi.mock('@podman-desktop/api', async () => {
         dispose: vi.fn(),
       }),
     },
+    provider: {
+      createProvider: (): podmanDesktopApi.Provider =>
+        ({
+          setVmProviderConnectionFactory: vi.fn(),
+        }) as unknown as podmanDesktopApi.Provider,
+    },
   };
 });
 

--- a/packages/backend/src/extension.ts
+++ b/packages/backend/src/extension.ts
@@ -26,8 +26,68 @@ import { HistoryNotifier } from './history/historyNotifier';
 import { Messages } from '/@shared/src/messages/Messages';
 import { satisfies, minVersion, coerce } from 'semver';
 import { engines } from '../package.json';
+import * as macadamJSPackage from '@crc-org/macadam.js';
+import { isHyperVEnabled, isWSLEnabled } from './macadam/win/utils';
+import { getErrorMessage, verifyContainerProivder } from './macadam/utils';
+import { LoggerDelegator } from './macadam/logger';
+import { ProviderConnectionShellAccessImpl } from './macadam/macadam-machine-stream';
+import { macadamName } from './constants';
 
 export const telemetryLogger = extensionApi.env.createTelemetryLogger();
+
+const EXTENSION_DESCRIPTION_MARKDOWN = `Bootable container-based virtual machines run via Macadam`;
+
+let stopLoop = false;
+
+type StatusHandler = (name: string, event: extensionApi.ProviderConnectionStatus) => void;
+const macadamMachinesInfo = new Map<string, MachineInfo>();
+const currentConnections = new Map<string, extensionApi.Disposable>();
+
+let wslAndHypervEnabledContextValue = false;
+const WSL_HYPERV_ENABLED_KEY = 'macadam.wslHypervEnabled';
+
+const listeners = new Set<StatusHandler>();
+
+export interface BinaryInfo {
+  path: string;
+  version: string;
+  installationSource: 'extension' | 'external';
+}
+
+export type MachineInfo = {
+  name: string;
+  image: string;
+  cpus: number;
+  memory: number;
+  diskSize: number;
+  port: number;
+  remoteUsername: string;
+  identityPath: string;
+  vmType: string;
+};
+
+type MachineJSON = {
+  Name: string;
+  Image: string;
+  CPUs: number;
+  Memory: string;
+  DiskSize: string;
+  Running: boolean;
+  Starting: boolean;
+  Port: number;
+  RemoteUsername: string;
+  IdentityPath: string;
+  VMType: string;
+};
+
+type MachineJSONListOutput = {
+  list: MachineJSON[];
+  error: string;
+};
+
+export let macadam: macadamJSPackage.Macadam;
+
+export const macadamMachinesStatuses = new Map<string, extensionApi.ProviderConnectionStatus>();
 
 export async function activate(extensionContext: ExtensionContext): Promise<void> {
   console.log('starting bootc extension');
@@ -114,6 +174,15 @@ export async function activate(extensionContext: ExtensionContext): Promise<void
       await openBuildPage(panel, image);
     }),
   );
+
+  macadam = new macadamJSPackage.Macadam(macadamName);
+  await macadam.init();
+
+  const provider = await createProvider(extensionContext);
+
+  monitorMachines(provider, extensionContext).catch((error: unknown) => {
+    console.error('Error while monitoring machines', error);
+  });
 }
 
 function checkVersion(version: string): boolean {
@@ -158,6 +227,340 @@ export async function getConfigurationValue<T>(property: string): Promise<T | un
   return extensionApi.configuration.getConfiguration('bootc').get<T>(property);
 }
 
+async function getJSONMachineList(): Promise<MachineJSONListOutput> {
+  const vmProviders: (string | undefined)[] = [];
+
+  if (extensionApi.env.isWindows) {
+    let hypervEnabled = false;
+    let wslEnabled = false;
+    if (await isWSLEnabled()) {
+      wslEnabled = true;
+      vmProviders.push('wsl');
+    }
+
+    if (await isHyperVEnabled()) {
+      hypervEnabled = true;
+      vmProviders.push('hyperv');
+    }
+    // update context "wsl-hyperv enabled" value
+    updateWSLHyperVEnabledContextValue(wslEnabled && hypervEnabled);
+  }
+
+  if (extensionApi.env.isMac) {
+    vmProviders.push('applehv');
+  }
+
+  if (vmProviders.length === 0) {
+    // in all other cases we set undefined so that it executes normally by using the default vm provider
+    vmProviders.push(undefined);
+  }
+
+  const list: MachineJSON[] = [];
+  let error = '';
+
+  try {
+    for (const provider of vmProviders) {
+      const machineListOutput = await getJSONMachineListByProvider(provider);
+      list.push(...machineListOutput.list);
+      if (machineListOutput.error && machineListOutput.error.trim() !== '') {
+        error += machineListOutput.error + '\n';
+      }
+    }
+  } catch (err) {
+    error = getErrorMessage(err);
+  }
+
+  return { list, error };
+}
+
+export async function getJSONMachineListByProvider(vmProvider?: string): Promise<MachineJSONListOutput> {
+  let stdout: macadamJSPackage.VmDetails[] = [];
+  let stderr = '';
+  try {
+    stdout = await macadam.listVms({ containerProvider: verifyContainerProivder(vmProvider ?? '') });
+  } catch (err: unknown) {
+    stderr = `${err}`;
+  }
+  return {
+    list: stdout,
+    error: stderr,
+  };
+}
+
+async function startMachine(
+  provider: extensionApi.Provider,
+  machineInfo: MachineInfo,
+  context?: extensionApi.LifecycleContext,
+  logger?: extensionApi.Logger,
+): Promise<void> {
+  const telemetryRecords: Record<string, unknown> = {};
+  telemetryRecords.provider = 'macadam';
+  const startTime = performance.now();
+
+  try {
+    await macadam.startVm({
+      name: machineInfo.name,
+      containerProvider: verifyContainerProivder(machineInfo.vmType),
+      runOptions: { logger: new LoggerDelegator(context, logger) },
+    });
+    provider.updateStatus('started');
+  } catch (err) {
+    telemetryRecords.error = err;
+    console.error(err);
+    throw err;
+  } finally {
+    // send telemetry event
+    const endTime = performance.now();
+    telemetryRecords.duration = endTime - startTime;
+    //in the POC we do not send any telemetry
+    // sendTelemetryRecords('macadam.machine.start', telemetryRecords, true);
+  }
+}
+
+async function stopMachine(
+  provider: extensionApi.Provider,
+  machineInfo: MachineInfo,
+  context?: extensionApi.LifecycleContext,
+  logger?: extensionApi.Logger,
+): Promise<void> {
+  const startTime = performance.now();
+  const telemetryRecords: Record<string, unknown> = {};
+  telemetryRecords.provider = 'macadam';
+  try {
+    await macadam.stopVm({
+      name: machineInfo.name,
+      containerProvider: verifyContainerProivder(machineInfo.vmType),
+      runOptions: { logger: new LoggerDelegator(context, logger) },
+    });
+    provider.updateStatus('stopped');
+  } catch (err: unknown) {
+    telemetryRecords.error = err;
+    throw err;
+  } finally {
+    // send telemetry event
+    const endTime = performance.now();
+    telemetryRecords.duration = endTime - startTime;
+    //in the POC we do not send any telemetry
+    //sendTelemetryRecords('macadam.machine.stop', telemetryRecords, false);
+  }
+}
+
+async function registerProviderFor(
+  provider: extensionApi.Provider,
+  machineInfo: MachineInfo,
+  context: extensionApi.ExtensionContext,
+): Promise<void> {
+  const lifecycle: extensionApi.ProviderConnectionLifecycle = {
+    start: async (context, logger): Promise<void> => {
+      await startMachine(provider, machineInfo, context, logger);
+    },
+    stop: async (context, logger): Promise<void> => {
+      await stopMachine(provider, machineInfo, context, logger);
+    },
+    delete: async (logger): Promise<void> => {
+      await macadam.removeVm({
+        name: machineInfo.name,
+        containerProvider: verifyContainerProivder(machineInfo.vmType),
+        runOptions: { logger },
+      });
+    },
+  };
+
+  const providerConnectionShellAccess = new ProviderConnectionShellAccessImpl(machineInfo);
+  context.subscriptions.push(providerConnectionShellAccess);
+
+  const vmProviderConnection: extensionApi.VmProviderConnection = {
+    name: machineInfo.name,
+    status: () => macadamMachinesStatuses.get(machineInfo.image) ?? 'unknown',
+    shellAccess: providerConnectionShellAccess,
+    lifecycle,
+  };
+
+  const disposable = provider.registerVmProviderConnection(vmProviderConnection);
+  provider.updateStatus('ready');
+
+  // get configuration for this connection
+  const vmConfiguration = extensionApi.configuration.getConfiguration('macadam', vmProviderConnection);
+
+  // Set values for the machine
+  await vmConfiguration.update('machine.cpus', machineInfo.cpus);
+  await vmConfiguration.update('machine.memory', machineInfo.memory);
+  await vmConfiguration.update('machine.diskSize', machineInfo.diskSize);
+
+  currentConnections.set(machineInfo.image, disposable);
+}
+
+async function updateMachines(provider: extensionApi.Provider, context: extensionApi.ExtensionContext): Promise<void> {
+  // init machines available
+  const machineListOutput = await getJSONMachineList();
+
+  if (machineListOutput.error) {
+    // TODO handle the error
+    console.error(machineListOutput.error);
+  }
+
+  // parse output
+  const machines = machineListOutput.list;
+
+  // update status of existing machines - in the POC only one can exist, just to keep code that can be reused in future
+  for (const machine of machines) {
+    const running = machine?.Running === true;
+    let status: extensionApi.ProviderConnectionStatus = running ? 'started' : 'stopped';
+
+    // update the status to starting if the machine is running but still starting
+    const starting = machine?.Starting === true;
+    if (starting) {
+      status = 'starting';
+    }
+
+    const previousStatus = macadamMachinesStatuses.get(machine.Image);
+    if (previousStatus !== status) {
+      // notify status change
+      listeners.forEach(listener => listener(machine.Image, status));
+      macadamMachinesStatuses.set(machine.Image, status);
+    }
+
+    // TODO update cpu/memory/disk usage
+
+    macadamMachinesInfo.set(machine.Image, {
+      name: machine.Name,
+      image: machine.Image,
+      memory: Number(machine.Memory),
+      cpus: Number(machine.CPUs),
+      diskSize: Number(machine.DiskSize),
+      port: machine.Port,
+      remoteUsername: machine.RemoteUsername,
+      identityPath: machine.IdentityPath,
+      vmType: machine.VMType,
+    });
+
+    if (!macadamMachinesStatuses.has(machine.Image)) {
+      macadamMachinesStatuses.set(machine.Image, status);
+    }
+  }
+
+  // remove machine no longer there
+  const machinesToRemove = Array.from(macadamMachinesStatuses.keys()).filter(
+    machine => !machines.find(m => m.Image === machine),
+  );
+  machinesToRemove.forEach(machine => {
+    macadamMachinesStatuses.delete(machine);
+  });
+
+  // create connections for new machines
+  const connectionsToCreate = Array.from(macadamMachinesStatuses.keys()).filter(
+    machineStatusKey => !currentConnections.has(machineStatusKey),
+  );
+  await Promise.all(
+    connectionsToCreate.map(async machineName => {
+      const podmanMachineInfo = macadamMachinesInfo.get(machineName);
+      if (podmanMachineInfo) {
+        await registerProviderFor(provider, podmanMachineInfo, context);
+      }
+    }),
+  );
+
+  // delete connections for machines no longer there
+  machinesToRemove.forEach(machine => {
+    const disposable = currentConnections.get(machine);
+    if (disposable) {
+      disposable.dispose();
+      currentConnections.delete(machine);
+    }
+  });
+
+  // If the machine length is zero and we are on macOS or Windows,
+  // we will update the provider as being 'installed', or ready / starting / configured if there is a machine
+  // if we are on Linux, ignore this as podman machine is OPTIONAL and the provider status in Linux is based upon
+  // the native podman installation / not machine.
+  if (!extensionApi.env.isLinux) {
+    if (machines.length === 0) {
+      if (provider.status !== 'configuring') {
+        provider.updateStatus('installed');
+      }
+    } else {
+      /*
+       * The machine can have 3 states, based on `Starting` and `Running` fields:
+       * - !Running && !Starting -> configured
+       * -  Running &&  Starting -> starting
+       * -  Running && !Starting -> ready
+       */
+      const atLeastOneMachineRunning = machines.some(machine => machine.Running && !machine.Starting);
+      const atLeastOneMachineStarting = machines.some(machine => machine.Starting);
+      // if a machine is running it's started else it is ready
+      if (atLeastOneMachineRunning) {
+        provider.updateStatus('ready');
+      } else if (atLeastOneMachineStarting) {
+        // update to starting
+        provider.updateStatus('starting');
+      } else {
+        // needs to start a machine
+        provider.updateStatus('configured');
+      }
+
+      // Finally, we check to see if the machine that is running is set by default or not on the CLI
+      // this will create a dialog that will ask the user if they wish to set the running machine as default.
+      // this should only run if we at least one machine
+      //await checkDefaultMachine(machines);
+    }
+  }
+}
+
+async function timeout(time: number): Promise<void> {
+  return new Promise<void>(resolve => {
+    setTimeout(resolve, time);
+  });
+}
+
+async function monitorMachines(provider: extensionApi.Provider, context: extensionApi.ExtensionContext): Promise<void> {
+  // call us again
+  if (!stopLoop) {
+    try {
+      await updateMachines(provider, context);
+    } catch (error) {
+      // ignore the update of machines
+      console.warn('Error updating machines', error);
+    }
+    await timeout(5000);
+    monitorMachines(provider, context).catch((error: unknown) => {
+      console.error('Error monitoring machines', error);
+    });
+  }
+}
+
+async function createProvider(extensionContext: extensionApi.ExtensionContext): Promise<extensionApi.Provider> {
+  const providerOptions: extensionApi.ProviderOptions = {
+    name: 'Bootc VMs',
+    id: 'bootc',
+    status: 'unknown',
+    images: {
+      icon: './icon.png',
+      logo: {
+        dark: './icon.png',
+        light: './icon.png',
+      },
+    },
+    emptyConnectionMarkdownDescription: EXTENSION_DESCRIPTION_MARKDOWN,
+  };
+
+  const provider = extensionApi.provider.createProvider(providerOptions);
+
+  extensionContext.subscriptions.push(provider);
+
+  // enable factory
+  provider.setVmProviderConnectionFactory({});
+
+  return provider;
+}
+
+function updateWSLHyperVEnabledContextValue(value: boolean): void {
+  if (wslAndHypervEnabledContextValue !== value) {
+    wslAndHypervEnabledContextValue = value;
+    extensionApi.context.setValue(WSL_HYPERV_ENABLED_KEY, value);
+  }
+}
+
 export async function deactivate(): Promise<void> {
+  stopLoop = true;
   console.log('stopping bootc extension');
 }

--- a/packages/backend/src/macadam/base-check.ts
+++ b/packages/backend/src/macadam/base-check.ts
@@ -1,0 +1,73 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import type * as extensionApi from '@podman-desktop/api';
+
+export interface FailureObject {
+  description: string;
+  docLinksDescription?: string;
+  docLinks?: extensionApi.CheckResultLink;
+  fixCommand?: extensionApi.CheckResultFixCommand;
+}
+
+export abstract class BaseCheck implements extensionApi.InstallCheck {
+  abstract title: string;
+  abstract execute(): Promise<extensionApi.CheckResult>;
+
+  protected createFailureResult(failureObject: FailureObject): extensionApi.CheckResult {
+    const result: extensionApi.CheckResult = { successful: false, description: failureObject.description };
+    if (failureObject.docLinksDescription) {
+      result.docLinksDescription = failureObject.docLinksDescription;
+    }
+    if (failureObject.docLinks) {
+      result.docLinks = [{ url: failureObject.docLinks.url, title: failureObject.docLinks.title }];
+    }
+    if (failureObject.fixCommand) {
+      result.fixCommand = {
+        id: failureObject.fixCommand.id,
+        title: failureObject.fixCommand.title,
+      };
+    }
+    return result;
+  }
+
+  protected createSuccessfulResult(): extensionApi.CheckResult {
+    return { successful: true };
+  }
+}
+
+export class SequenceCheck extends BaseCheck {
+  title: string;
+
+  constructor(
+    title: string,
+    private checks: BaseCheck[],
+  ) {
+    super();
+    this.title = title;
+  }
+
+  async execute(): Promise<extensionApi.CheckResult> {
+    for (const check of this.checks) {
+      const result = await check.execute();
+      if (!result.successful) {
+        return result;
+      }
+    }
+    return this.createSuccessfulResult();
+  }
+}

--- a/packages/backend/src/macadam/logger.ts
+++ b/packages/backend/src/macadam/logger.ts
@@ -1,0 +1,67 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type * as extensionApi from '@podman-desktop/api';
+
+/**
+ * LoggerDelegator class implements the Logger interface and acts as a delegator for multiple Logger instances.
+ * It allows to combine multiple loggers into a single logger and forwards log, error, and warn messages to each
+ * individual logger in its internal list.
+ *
+ * This class addresses a specific use case where the new process API requires a single logger object, but we have
+ * separate loggers and lifecycle contexts, where each lifecycle context also contains a logger object.
+ * To accommodate this scenario, this adapter is created to hold multiple logger objects
+ * and delegate method calls to each of them, providing a unified logger interface for the process API.
+ *
+ * If a similar use case arises in other extensions, it will be necessary to extend the RunOptions interface
+ * by adding a new field called `lifecycleContext` that can hold a LifecycleContext instance.
+ * Subsequently, the LoggerDelegator class can be removed, and the new RunOptions interface with the `lifecycleContext`
+ * field can be used directly, simplifying the process of passing the logger to the process API while preserving
+ * the necessary functionalities.
+ */
+export class LoggerDelegator implements extensionApi.Logger {
+  private loggers: extensionApi.Logger[] = [];
+
+  constructor(...loggersOrContexts: (extensionApi.Logger | extensionApi.LifecycleContext | undefined)[]) {
+    loggersOrContexts.forEach(loggerOrContext => {
+      if (loggerOrContext === undefined) {
+        return;
+      }
+      if (typeof loggerOrContext.log === 'object') {
+        this.loggers.push(loggerOrContext.log);
+      } else if (typeof loggerOrContext.log === 'function') {
+        this.loggers.push(loggerOrContext as extensionApi.Logger);
+      }
+    });
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  log(...data: any[]): void {
+    this.loggers.forEach(logger => logger.log(...data));
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  error(...data: any[]): void {
+    this.loggers.forEach(logger => logger.error(...data));
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  warn(...data: any[]): void {
+    this.loggers.forEach(logger => logger.warn(...data));
+  }
+}

--- a/packages/backend/src/macadam/macadam-machine-stream.ts
+++ b/packages/backend/src/macadam/macadam-machine-stream.ts
@@ -1,0 +1,138 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import * as fs from 'node:fs';
+
+import type {
+  Disposable,
+  Event,
+  ProviderConnectionShellAccess,
+  ProviderConnectionShellAccessData,
+  ProviderConnectionShellAccessError,
+  ProviderConnectionShellAccessSession,
+  ProviderConnectionShellDimensions,
+} from '@podman-desktop/api';
+import { EventEmitter } from '@podman-desktop/api';
+import type { ClientChannel } from 'ssh2';
+import { Client } from 'ssh2';
+
+import type { MachineInfo } from '../extension';
+
+export class ProviderConnectionShellAccessImpl implements ProviderConnectionShellAccess, Disposable {
+  #host: string;
+  #port: number;
+  #username: string;
+  #privateKey: string;
+  #client: Client | undefined;
+  #stream: ClientChannel | undefined;
+
+  constructor(private readonly machine: MachineInfo) {
+    this.#host = 'localhost';
+    this.#port = machine.port;
+    this.#username = machine.remoteUsername;
+    this.#privateKey = machine.identityPath;
+  }
+
+  dispose(): void {
+    this.close();
+  }
+
+  onDataEmit = new EventEmitter<ProviderConnectionShellAccessData>();
+  onData: Event<ProviderConnectionShellAccessData> = this.onDataEmit.event;
+
+  onErrorEmit = new EventEmitter<ProviderConnectionShellAccessError>();
+  onError: Event<ProviderConnectionShellAccessError> = this.onErrorEmit.event;
+
+  onEndEmit = new EventEmitter<void>();
+  onEnd: Event<void> = this.onEndEmit.event;
+
+  write(data: string): void {
+    this.#stream?.write(data);
+  }
+
+  resize(dimensions: ProviderConnectionShellDimensions): void {
+    // rows and cols override width and height when rows and cols are non-zero.
+    this.#stream?.setWindow(dimensions.rows, dimensions.cols, 0, 0);
+  }
+
+  protected disposeListeners(): void {
+    this.onDataEmit.dispose();
+    this.onErrorEmit.dispose();
+    this.onEndEmit.dispose();
+  }
+
+  // Going to different tab => closing session + removing listeners
+  // Closes stream with client
+  close(): void {
+    this.closeStream();
+    this.disposeListeners();
+  }
+
+  // Closes stream with client
+  closeStream(): void {
+    this.#stream?.close();
+    this.#client?.end();
+    this.#client?.destroy();
+    this.#stream = undefined;
+    this.#client = undefined;
+  }
+
+  open(): ProviderConnectionShellAccessSession {
+    this.#client = new Client();
+    this.#client
+      .on('ready', () => {
+        this.#client?.shell((err, stream) => {
+          if (err) {
+            console.error(err);
+            this.onErrorEmit.fire({ error: err.message });
+            return;
+          }
+          this.#stream = stream;
+
+          stream
+            .on('close', () => {
+              console.error('close');
+              this.onEndEmit.fire();
+              this.closeStream();
+            })
+            .on('data', (data: string) => {
+              this.onDataEmit.fire({ data: data });
+            });
+        });
+      })
+      .on('error', err => {
+        console.error(err);
+        this.onErrorEmit.fire({ error: err.message });
+      })
+      .connect({
+        host: this.#host,
+        port: this.#port,
+        username: this.#username,
+        privateKey: fs.readFileSync(this.#privateKey),
+      });
+
+    return {
+      onData: this.onData,
+      onError: this.onError,
+      onEnd: this.onEnd,
+      write: this.write.bind(this),
+      resize: this.resize.bind(this),
+      close: this.close,
+    };
+  }
+}

--- a/packages/backend/src/macadam/utils.ts
+++ b/packages/backend/src/macadam/utils.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024-2025 Red Hat, Inc.
+ * Copyright (C) 2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,9 +16,19 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-// Image related
-export const bootcImageBuilder = 'bootc-image-builder';
-export const bootcImageBuilderCentos =
-  'quay.io/centos-bootc/bootc-image-builder:sha256-de948b4d66006b26e2cb6a051afdb3cfcd569c9db52bb6fe7b1f2236ad216207';
-export const bootcImageBuilderRHEL = 'registry.redhat.io/rhel9/bootc-image-builder:9.5';
-export const macadamName = 'bootc';
+export function getErrorMessage(err: unknown): string {
+  if (err && typeof err === 'object' && 'message' in err) {
+    return String(err.message);
+  } else if (typeof err === 'string') {
+    return err;
+  }
+  return '';
+}
+
+export function verifyContainerProivder(containerProvider: string): 'wsl' | 'hyperv' | 'applehv' | undefined {
+  if (containerProvider === 'wsl' || containerProvider === 'hyperv' || containerProvider === 'applehv') {
+    return containerProvider;
+  } else {
+    return undefined;
+  }
+}

--- a/packages/backend/src/macadam/win/hyperv-helper.ts
+++ b/packages/backend/src/macadam/win/hyperv-helper.ts
@@ -1,0 +1,81 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type * as extensionApi from '@podman-desktop/api';
+
+import { BaseCheck } from '../base-check';
+import { getPowerShellClient } from './powershell';
+import { isPodmanDesktopElevated, isUserAdmin } from './utils';
+
+async function isHyperVInstalled(): Promise<boolean> {
+  const client = await getPowerShellClient();
+  return client.isHyperVInstalled();
+}
+
+async function isHyperVRunning(): Promise<boolean> {
+  const client = await getPowerShellClient();
+  return client.isHyperVRunning();
+}
+
+export class HyperVCheck extends BaseCheck {
+  title = 'Hyper-V installed';
+  static readonly PODMAN_MINIMUM_VERSION_FOR_HYPERV = '5.2.0';
+
+  constructor() {
+    super();
+  }
+
+  async execute(): Promise<extensionApi.CheckResult> {
+    if (!(await isUserAdmin())) {
+      return this.createFailureResult({
+        description: 'You must have administrative rights to run Hyper-V Podman machines',
+        docLinksDescription: 'Contact your Administrator to setup Hyper-V.',
+        docLinks: {
+          url: 'https://learn.microsoft.com/en-us/virtualization/hyper-v-on-windows/quick-start/enable-hyper-v',
+          title: 'Hyper-V Manual Installation Steps',
+        },
+      });
+    }
+    if (!(await isPodmanDesktopElevated())) {
+      return this.createFailureResult({
+        description: 'You must run Podman Desktop with administrative rights to run Hyper-V Podman machines.',
+      });
+    }
+    if (!(await isHyperVInstalled())) {
+      return this.createFailureResult({
+        description: 'Hyper-V is not installed on your system.',
+        docLinksDescription: 'call DISM /Online /Enable-Feature /All /FeatureName:Microsoft-Hyper-V in a terminal',
+        docLinks: {
+          url: 'https://learn.microsoft.com/en-us/virtualization/hyper-v-on-windows/quick-start/enable-hyper-v',
+          title: 'Hyper-V Manual Installation Steps',
+        },
+      });
+    }
+    if (!(await isHyperVRunning())) {
+      return this.createFailureResult({
+        description: 'Hyper-V is not running on your system.',
+        docLinksDescription: 'call sc start vmms in a terminal',
+        docLinks: {
+          url: 'https://learn.microsoft.com/en-us/virtualization/hyper-v-on-windows/quick-start/enable-hyper-v',
+          title: 'Hyper-V Manual Installation Steps',
+        },
+      });
+    }
+    return this.createSuccessfulResult();
+  }
+}

--- a/packages/backend/src/macadam/win/powershell.ts
+++ b/packages/backend/src/macadam/win/powershell.ts
@@ -1,0 +1,94 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/* eslint-disable sonarjs/no-ignored-exceptions */
+import * as extensionApi from '@podman-desktop/api';
+
+export async function getPowerShellClient(): Promise<PowerShellClient> {
+  return new PowerShell5Client();
+}
+
+export interface PowerShellClient {
+  isVirtualMachineAvailable(): Promise<boolean>;
+  isUserAdmin(): Promise<boolean>;
+  isHyperVInstalled(): Promise<boolean>;
+  isHyperVRunning(): Promise<boolean>;
+  isRunningElevated(): Promise<boolean>;
+}
+
+const PowerShell5Exe = 'powershell.exe';
+class PowerShell5Client implements PowerShellClient {
+  async isVirtualMachineAvailable(): Promise<boolean> {
+    try {
+      // set CurrentUICulture to force output in english
+      const { stdout: res } = await extensionApi.process.exec(
+        PowerShell5Exe,
+        [
+          '[System.Console]::OutputEncoding = [System.Text.Encoding]::Unicode; (Get-WmiObject -Query "Select * from Win32_OptionalFeature where InstallState = \'1\'").Name | select-string VirtualMachinePlatform',
+        ],
+        { encoding: 'utf16le' },
+      );
+      if (res.indexOf('VirtualMachinePlatform') >= 0) {
+        return true;
+      }
+    } catch (err) {
+      // ignore error, this means that VirtualMachinePlatform not enabled
+    }
+    return false;
+  }
+
+  async isUserAdmin(): Promise<boolean> {
+    try {
+      const { stdout: res } = await extensionApi.process.exec(PowerShell5Exe, [
+        '$null -ne (whoami /groups /fo csv | ConvertFrom-Csv | Where-Object {$_.SID -eq "S-1-5-32-544"})',
+      ]);
+      return res.trim() === 'True';
+    } catch (err: unknown) {
+      return false;
+    }
+  }
+
+  async isHyperVInstalled(): Promise<boolean> {
+    try {
+      await extensionApi.process.exec(PowerShell5Exe, ['Get-Service vmms']);
+      return true;
+    } catch (err: unknown) {
+      return false;
+    }
+  }
+
+  async isHyperVRunning(): Promise<boolean> {
+    try {
+      const result = await extensionApi.process.exec(PowerShell5Exe, ['@(Get-Service vmms).Status']);
+      return result.stdout === 'Running';
+    } catch (err: unknown) {
+      return false;
+    }
+  }
+
+  async isRunningElevated(): Promise<boolean> {
+    try {
+      const { stdout: res } = await extensionApi.process.exec(PowerShell5Exe, [
+        '(New-Object Security.Principal.WindowsPrincipal([Security.Principal.WindowsIdentity]::GetCurrent())).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)',
+      ]);
+      return res.trim() === 'True';
+    } catch (err: unknown) {
+      return false;
+    }
+  }
+}

--- a/packages/backend/src/macadam/win/utils.ts
+++ b/packages/backend/src/macadam/win/utils.ts
@@ -1,0 +1,52 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import * as extensionApi from '@podman-desktop/api';
+
+import { SequenceCheck } from '../base-check';
+import { HyperVCheck } from './hyperv-helper';
+import { getPowerShellClient } from './powershell';
+import { WSL2Check, WSLVersionCheck } from './wsl-helper';
+
+export async function isWSLEnabled(): Promise<boolean> {
+  if (!extensionApi.env.isWindows) {
+    return false;
+  }
+  const wslCheck = new SequenceCheck('WSL platform', [new WSLVersionCheck(), new WSL2Check()]);
+  const wslCheckResult = await wslCheck.execute();
+  return wslCheckResult.successful;
+}
+
+export async function isHyperVEnabled(): Promise<boolean> {
+  if (!extensionApi.env.isWindows) {
+    return false;
+  }
+  const hyperVCheck = new HyperVCheck();
+  const hyperVCheckResult = await hyperVCheck.execute();
+  return hyperVCheckResult.successful;
+}
+
+export async function isUserAdmin(): Promise<boolean> {
+  const client = await getPowerShellClient();
+  return client.isUserAdmin();
+}
+
+export async function isPodmanDesktopElevated(): Promise<boolean> {
+  const client = await getPowerShellClient();
+  return client.isRunningElevated();
+}

--- a/packages/backend/src/macadam/win/wsl-helper.ts
+++ b/packages/backend/src/macadam/win/wsl-helper.ts
@@ -1,0 +1,275 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/* eslint-disable sonarjs/no-ignored-exceptions */
+import * as extensionApi from '@podman-desktop/api';
+import { compare } from 'compare-versions';
+
+import { BaseCheck } from '../base-check';
+import { isUserAdmin } from './utils';
+
+export interface WSLVersionInfo {
+  wslVersion?: string;
+  kernelVersion?: string;
+  windowsVersion?: string;
+}
+
+export class WslHelper {
+  async getWSLVersionData(): Promise<WSLVersionInfo> {
+    const { stdout } = await extensionApi.process.exec('wsl', ['--version'], { encoding: 'utf16le' });
+    /*
+      got something like
+      WSL version: 1.2.5.0
+      Kernel version: 5.15.90.1
+      WSLg version: 1.0.51
+      MSRDC version: 1.2.3770
+      Direct3D version: 1.608.2-61064218
+      DXCore version: 10.0.25131.1002-220531-1700.rs-onecore-base2-hyp
+      Windows version: 10.0.22621.2134
+
+      N.B: the label before the colon symbol changes based on the system language. In an italian system you would have
+
+      Versione WSL: 1.2.5.0
+      Versione kernel: 5.15.90.1
+      ...
+    */
+
+    // split the output in lines
+    const lines = normalizeWSLOutput(stdout).split('\n');
+
+    // the first line should display the version of the wsl - WSL version: 1.2.5.0
+    const wslVersion = getVersionFromWSLOutput(lines[0], 'wsl');
+
+    // the second line should display the kernel version - Kernel version: 5.15.90.1
+    const kernelVersion = getVersionFromWSLOutput(lines[1], 'kernel');
+
+    // the last line should display the Windows version - Windows version: 10.0.22621.2134
+    const windowsVersion = getVersionFromWSLOutput(lines[6], 'windows');
+
+    return { wslVersion, kernelVersion, windowsVersion };
+  }
+}
+
+/**
+ * it extract the content after the colon which should be the version of the tool/system
+ * @param line the content to analyze
+ * @param value the tool/system to find the version for
+ * @returns the content after the colon if the line belongs to the tool/system we are searching info for
+ */
+function getVersionFromWSLOutput(line: string, value: string): string | undefined {
+  if (!line) {
+    return undefined;
+  }
+  const colonPosition = indexOfColons(line);
+  if (colonPosition >= 0 && line.substring(0, colonPosition).toLowerCase().includes(value)) {
+    return line.substring(colonPosition + 1).trim();
+  }
+  return undefined;
+}
+
+/**
+ * When using a non-latin language like chinese, WSL also uses a different value for the colon symbol
+ * There are three colons:
+ * symbol | name            | number
+ * :      | vertical colon  | 58
+ * ：     | fullwidth colon | 65306
+ * ﹕     | small colon     | 65109
+ * This function returns the position of the first colon symbol found in the string
+ */
+function indexOfColons(value: string): number {
+  for (let i = 0; i < value.length; i++) {
+    const codeChar = value.charCodeAt(i);
+    if (codeChar === 58 || codeChar === 65306 || codeChar === 65109) {
+      return i;
+    }
+  }
+  return -1;
+}
+
+// this is workaround, wsl2 some time send output in utf16le, but we treat that as utf8,
+// this code just eliminate every 'empty' character
+/**
+ * this function is a workaround to clean the output received by WSL2. Some time it sends output in utf16le, but we treat that as utf8,
+ * this code just eliminate every 'empty' character
+ * @param out the string to clean
+ * @returns the string cleaned
+ */
+function normalizeWSLOutput(out: string): string {
+  let str = '';
+  for (let i = 0; i < out.length; i++) {
+    if (out.charCodeAt(i) !== 0) {
+      str += out.charAt(i);
+    }
+  }
+  return str;
+}
+
+export class WSLVersionCheck extends BaseCheck {
+  title = 'WSL Version';
+
+  minVersion = '1.2.5';
+
+  async execute(): Promise<extensionApi.CheckResult> {
+    try {
+      const wslHelper = new WslHelper();
+      const wslVersionData = await wslHelper.getWSLVersionData();
+      if (wslVersionData.wslVersion) {
+        if (compare(wslVersionData.wslVersion, this.minVersion, '>=')) {
+          return this.createSuccessfulResult();
+        } else {
+          return this.createFailureResult({
+            description: `Your WSL version is ${wslVersionData.wslVersion} but it should be >= ${this.minVersion}.`,
+            docLinksDescription: `Call 'wsl --update' to update your WSL installation. If you do not have access to the Windows store you can run 'wsl --update --web-download'. If you still receive an error please contact your IT administator as 'Windows Store Applications' may have been disabled.`,
+          });
+        }
+      }
+    } catch (err) {
+      // ignore error
+    }
+    return this.createFailureResult({
+      description: `WSL version should be >= ${this.minVersion}.`,
+      docLinksDescription: `Call 'wsl --version' in a terminal to check your wsl version.`,
+    });
+  }
+}
+
+export class WSL2Check extends BaseCheck {
+  title = 'WSL2 Installed';
+  installWSLCommandId = 'podman.onboarding.installWSL';
+
+  constructor(private extensionContext?: extensionApi.ExtensionContext) {
+    super();
+  }
+
+  async init(): Promise<void> {
+    if (this.extensionContext) {
+      const wslCommand = extensionApi.commands.registerCommand(this.installWSLCommandId, async () => {
+        const installSucceeded = await this.installWSL();
+        if (installSucceeded) {
+          // if action succeeded, do a re-check of all podman requirements so user can be moved forward if all missing pieces have been installed
+          await extensionApi.commands.executeCommand('podman.onboarding.checkRequirementsCommand');
+        }
+      });
+      this.extensionContext.subscriptions.push(wslCommand);
+    }
+  }
+
+  async execute(): Promise<extensionApi.CheckResult> {
+    try {
+      const isAdmin = await isUserAdmin();
+      const isWSL = await this.isWSLPresent();
+      const isRebootNeeded = await this.isRebootNeeded();
+
+      if (!isWSL) {
+        if (isAdmin) {
+          return this.createFailureResult({
+            description: 'WSL2 is not installed.',
+            docLinksDescription: `Call 'wsl --install --no-distribution' in a terminal.`,
+            docLinks: {
+              url: 'https://learn.microsoft.com/en-us/windows/wsl/install',
+              title: 'WSL2 Manual Installation Steps',
+            },
+            fixCommand: {
+              id: this.installWSLCommandId,
+              title: 'Install WSL2',
+            },
+          });
+        } else {
+          return this.createFailureResult({
+            description: 'WSL2 is not installed or you do not have permissions to run WSL2.',
+            docLinksDescription: 'Contact your Administrator to setup WSL2.',
+            docLinks: {
+              url: 'https://learn.microsoft.com/en-us/windows/wsl/install',
+              title: 'WSL2 Manual Installation Steps',
+            },
+          });
+        }
+      } else if (isRebootNeeded) {
+        return this.createFailureResult({
+          description:
+            'WSL2 seems to be installed but the system needs to be restarted so the changes can take effect.',
+          docLinksDescription: `If already restarted, call 'wsl --install --no-distribution' in a terminal.`,
+          docLinks: {
+            url: 'https://learn.microsoft.com/en-us/windows/wsl/install',
+            title: 'WSL2 Manual Installation Steps',
+          },
+        });
+      }
+    } catch (err) {
+      return this.createFailureResult({
+        description: 'Could not detect WSL2',
+        docLinks: {
+          url: 'https://learn.microsoft.com/en-us/windows/wsl/install',
+          title: 'WSL2 Manual Installation Steps',
+        },
+      });
+    }
+
+    return this.createSuccessfulResult();
+  }
+
+  private async isWSLPresent(): Promise<boolean> {
+    try {
+      const { stdout: res } = await extensionApi.process.exec('wsl', ['--set-default-version', '2'], {
+        env: { WSL_UTF8: '1' },
+      });
+      const output = normalizeWSLOutput(res);
+      return !!output;
+    } catch (error) {
+      return false;
+    }
+  }
+
+  private async installWSL(): Promise<boolean> {
+    try {
+      await extensionApi.process.exec('wsl', ['--install', '--no-distribution'], {
+        env: { WSL_UTF8: '1' },
+      });
+
+      return true;
+    } catch (error) {
+      const runError = error as extensionApi.RunError;
+      let message = runError.message ? `${runError.message}\n` : '';
+      message += runError.stdout || '';
+      message += runError.stderr || '';
+      throw new Error(message);
+    }
+  }
+
+  private async isRebootNeeded(): Promise<boolean> {
+    try {
+      await extensionApi.process.exec('wsl', ['-l'], {
+        env: { WSL_UTF8: '1' },
+      });
+    } catch (error) {
+      // we only return true for the WSL_E_WSL_OPTIONAL_COMPONENT_REQUIRED error code
+      // as other errors may not be connected to a reboot, like
+      // WSL_E_DEFAULT_DISTRO_NOT_FOUND = wsl was installed without the default distro
+      const runError = error as extensionApi.RunError;
+      if (runError.stdout.includes('Wsl/WSL_E_WSL_OPTIONAL_COMPONENT_REQUIRED')) {
+        return true;
+      } else if (runError.stdout.includes('Wsl/WSL_E_DEFAULT_DISTRO_NOT_FOUND')) {
+        // treating this log differently as we install wsl without any distro
+        console.log('WSL has been installed without the default distribution');
+      } else {
+        console.error(error);
+      }
+    }
+    return false;
+  }
+}

--- a/packages/backend/vite.config.js
+++ b/packages/backend/vite.config.js
@@ -47,7 +47,7 @@ const config = {
       formats: ['cjs'],
     },
     rollupOptions: {
-      external: ['@podman-desktop/api', ...builtinModules.flatMap(p => [p, `node:${p}`])],
+      external: ['@podman-desktop/api', 'ssh2', ...builtinModules.flatMap(p => [p, `node:${p}`])],
       output: {
         entryFileNames: '[name].js',
       },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -119,9 +119,15 @@ importers:
       '@crc-org/macadam.js':
         specifier: 0.0.1-202505091153-d597ec3
         version: 0.0.1-202505091153-d597ec3
+      compare-versions:
+        specifier: ^6.1.1
+        version: 6.1.1
       semver:
         specifier: ^7.7.2
         version: 7.7.2
+      ssh2:
+        specifier: ^1.16.0
+        version: 1.16.0
     devDependencies:
       '@podman-desktop/api':
         specifier: 1.18.1
@@ -129,6 +135,9 @@ importers:
       '@types/node':
         specifier: ^22
         version: 22.15.17
+      '@types/ssh2':
+        specifier: ^1.15.5
+        version: 1.15.5
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.32.0
         version: 8.32.1(@typescript-eslint/parser@8.32.1(eslint@9.26.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.26.0(jiti@2.4.2))(typescript@5.8.3)
@@ -1212,6 +1221,9 @@ packages:
   '@types/marked@5.0.2':
     resolution: {integrity: sha512-OucS4KMHhFzhz27KxmWg7J+kIYqyqoW5kdIEI319hqARQQUTqhao3M/F+uFnDXD0Rg72iDDZxZNxq5gvctmLlg==}
 
+  '@types/node@18.19.100':
+    resolution: {integrity: sha512-ojmMP8SZBKprc3qGrGk8Ujpo80AXkrP7G2tOT4VWr5jlr5DHjsJF+emXJz+Wm0glmy4Js62oKMdZZ6B9Y+tEcA==}
+
   '@types/node@22.15.17':
     resolution: {integrity: sha512-wIX2aSZL5FE+MR0JlvF87BNVrtFWf6AE6rxSE9X7OwnVvoyCQjpzSRJ+M87se/4QCkCiebQAqrJ0y6fwIyi7nw==}
 
@@ -1220,6 +1232,9 @@ packages:
 
   '@types/semver@7.5.8':
     resolution: {integrity: sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==}
+
+  '@types/ssh2@1.15.5':
+    resolution: {integrity: sha512-N1ASjp/nXH3ovBHddRJpli4ozpk6UdDYIX4RJWFa9L1YKnzdhTlVmiGHm4DZnj/jLbqZpes4aeR30EFGQtvhQQ==}
 
   '@types/yargs-parser@21.0.3':
     resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
@@ -1561,6 +1576,9 @@ packages:
     resolution: {integrity: sha512-bMxMKAjg13EBSVscxTaYA4mRc5t1UAXa2kXiGTNfZ079HIWXEkKmkgFrh/nJqamaLSrXO5H4WFFkPEaLJWbs3A==}
     engines: {node: '>= 0.4'}
 
+  asn1@0.2.6:
+    resolution: {integrity: sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
@@ -1582,6 +1600,9 @@ packages:
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  bcrypt-pbkdf@1.0.2:
+    resolution: {integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==}
 
   body-parser@2.2.0:
     resolution: {integrity: sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==}
@@ -1613,6 +1634,10 @@ packages:
 
   buffer-crc32@0.2.13:
     resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
+
+  buildcheck@0.0.6:
+    resolution: {integrity: sha512-8f9ZJCUXyT1M35Jx7MkBgmBMo3oHTTBIPLiY9xyL0pl3T5RwcPEY8cUHr5LBNfu/fk6c2T4DJZuVM/8ZZT2D2A==}
+    engines: {node: '>=10.0.0'}
 
   builtin-modules@3.3.0:
     resolution: {integrity: sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==}
@@ -1737,6 +1762,9 @@ packages:
   compare-func@2.0.0:
     resolution: {integrity: sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==}
 
+  compare-versions@6.1.1:
+    resolution: {integrity: sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==}
+
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
@@ -1800,6 +1828,10 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  cpu-features@0.0.10:
+    resolution: {integrity: sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==}
+    engines: {node: '>=10.0.0'}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -3035,6 +3067,9 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
+  nan@2.22.2:
+    resolution: {integrity: sha512-DANghxFkS1plDdRsX0X9pm0Z6SJNN6gBdtXfanwoZ8hooC5gosGFSBGRYHUVPz1asKA/kMRqDRdHrluZ61SpBQ==}
+
   nano-spawn@1.0.1:
     resolution: {integrity: sha512-BfcvzBlUTxSDWfT+oH7vd6CbUV+rThLLHCIym/QO6GGLBsyVXleZs00fto2i2jzC/wPiBYk5jyOmpXWg4YopiA==}
     engines: {node: '>=20.18'}
@@ -3567,6 +3602,10 @@ packages:
   sprintf-js@1.1.3:
     resolution: {integrity: sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==}
 
+  ssh2@1.16.0:
+    resolution: {integrity: sha512-r1X4KsBGedJqo7h8F5c4Ybpcr5RjyP+aWIG007uBPRjmdQWfEiVLzSK71Zji1B9sKxwaCvD8y8cwSkYrlLiRRg==}
+    engines: {node: '>=10.16.0'}
+
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
 
@@ -3821,6 +3860,9 @@ packages:
     peerDependencies:
       typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
 
+  tweetnacl@0.14.5:
+    resolution: {integrity: sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==}
+
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
@@ -3863,6 +3905,9 @@ packages:
 
   unbox-primitive@1.0.2:
     resolution: {integrity: sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==}
+
+  undici-types@5.26.5:
+    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
@@ -4960,6 +5005,10 @@ snapshots:
 
   '@types/marked@5.0.2': {}
 
+  '@types/node@18.19.100':
+    dependencies:
+      undici-types: 5.26.5
+
   '@types/node@22.15.17':
     dependencies:
       undici-types: 6.21.0
@@ -4969,6 +5018,10 @@ snapshots:
       '@types/node': 22.15.17
 
   '@types/semver@7.5.8': {}
+
+  '@types/ssh2@1.15.5':
+    dependencies:
+      '@types/node': 18.19.100
 
   '@types/yargs-parser@21.0.3': {}
 
@@ -5374,6 +5427,10 @@ snapshots:
       is-array-buffer: 3.0.4
       is-shared-array-buffer: 1.0.3
 
+  asn1@0.2.6:
+    dependencies:
+      safer-buffer: 2.1.2
+
   assertion-error@2.0.1: {}
 
   autoprefixer@10.4.21(postcss@8.5.3):
@@ -5393,6 +5450,10 @@ snapshots:
   axobject-query@4.1.0: {}
 
   balanced-match@1.0.2: {}
+
+  bcrypt-pbkdf@1.0.2:
+    dependencies:
+      tweetnacl: 0.14.5
 
   body-parser@2.2.0:
     dependencies:
@@ -5440,6 +5501,9 @@ snapshots:
     optional: true
 
   buffer-crc32@0.2.13: {}
+
+  buildcheck@0.0.6:
+    optional: true
 
   builtin-modules@3.3.0: {}
 
@@ -5564,6 +5628,8 @@ snapshots:
       array-ify: 1.0.0
       dot-prop: 5.3.0
 
+  compare-versions@6.1.1: {}
+
   concat-map@0.0.1: {}
 
   concurrently@9.1.2:
@@ -5628,6 +5694,12 @@ snapshots:
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 5.8.3
+
+  cpu-features@0.0.10:
+    dependencies:
+      buildcheck: 0.0.6
+      nan: 2.22.2
+    optional: true
 
   cross-spawn@7.0.6:
     dependencies:
@@ -6973,6 +7045,9 @@ snapshots:
 
   ms@2.1.3: {}
 
+  nan@2.22.2:
+    optional: true
+
   nano-spawn@1.0.1: {}
 
   nanoid@3.3.11: {}
@@ -7492,6 +7567,14 @@ snapshots:
   sprintf-js@1.1.3:
     optional: true
 
+  ssh2@1.16.0:
+    dependencies:
+      asn1: 0.2.6
+      bcrypt-pbkdf: 1.0.2
+    optionalDependencies:
+      cpu-features: 0.0.10
+      nan: 2.22.2
+
   stable-hash@0.0.5: {}
 
   stackback@0.0.2: {}
@@ -7719,6 +7802,8 @@ snapshots:
       tslib: 1.14.1
       typescript: 5.8.3
 
+  tweetnacl@0.14.5: {}
+
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
@@ -7782,6 +7867,8 @@ snapshots:
       has-bigints: 1.0.2
       has-symbols: 1.0.3
       which-boxed-primitive: 1.0.2
+
+  undici-types@5.26.5: {}
 
   undici-types@6.21.0: {}
 


### PR DESCRIPTION
### What does this PR do?

Adds a Bootc VM provider to Settings > Resources. Only bootc extension created VMs appear in this section.

The bulk of code is direct copy pasta from the Macadam extension, which we'll need to keep in sync until we figure out how to share / where VMs belong. I've only added two 'eslint-disable sonarjs/no-ignored-exceptions' (better to keep code in sync than fix these in one place) and changed the labels/ descriptions.

Two new dependencies added: ssh2 and compare-versions.

### Screenshot / video of UI

<img width="721" alt="Screenshot 2025-05-07 at 11 45 25 AM" src="https://github.com/user-attachments/assets/c544fd4d-88dd-48e0-a08f-7856916ca787" />

### What issues does this PR fix or reference?

Main part of #1597.

### How to test this PR?

Create a couple VMs, confirm they work identically to before (but without requiring another extension).