### PR TITLE
chore: manually add macadam.js to the Containerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,2 @@
 node_modules
+!node_modules/@crc-org/macadam.js

--- a/Containerfile
+++ b/Containerfile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2024 Red Hat, Inc.
+# Copyright (C) 2024-2025 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -23,6 +23,11 @@ COPY LICENSE /extension/
 COPY packages/backend/icon.png /extension/
 COPY packages/backend/bootable.woff2 /extension/
 COPY README.md /extension/
+
+# We require the macadam.js binaries and library, so we will manually copy this over to the container image.
+# we rely on `pnpm build` before creating the container image, so we can safely assume that the macadam.js binaries are already present in the node_modules directory
+# and can copy them over to the container image.
+COPY node_modules/@crc-org/macadam.js /extension/node_modules/@crc-org/macadam.js
 
 FROM scratch
 


### PR DESCRIPTION
chore: manually add macadam.js to the Containerfile

### What does this PR do?

* Modifies the Containerfile so that the macadam.js library and binaries so that they can be used via OCI image install.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

N/A, no UI changes.

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/podman-desktop/extension-bootc/issues/1598

### How to test this PR?

1. Build the image (podman build) and push it to a container registry
2. Install via the container registry
3. See everything else works fine

<!-- Please explain steps to reproduce -->

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
