### PR TITLE
chore: add link to resources

### DIFF
--- a/packages/backend/src/api-impl.ts
+++ b/packages/backend/src/api-impl.ts
@@ -346,6 +346,10 @@ export class BootcApiImpl implements BootcApi {
     await podmanDesktopApi.env.openExternal(podmanDesktopApi.Uri.parse(link));
   }
 
+  async openResources(): Promise<void> {
+    return await podmanDesktopApi.navigation.navigateToResources();
+  }
+
   async generateUniqueBuildID(name: string): Promise<string> {
     return this.history.getUnusedHistoryName(name);
   }

--- a/packages/frontend/src/CreateVM.svelte
+++ b/packages/frontend/src/CreateVM.svelte
@@ -147,7 +147,7 @@ async function createVM(): Promise<void> {
       <EmptyScreen icon={faCheck} title="Virtual machine created" message={createSuccessMessage}>
         <p class="text-md text-[var(--pd-content-text)] pb-2 ">
           In order to use the virtual machine, you must install the <Link
-            externalRef="https://github.com/redhat-developer/podman-desktop-rhel-ext">Macadam extension</Link>.<br/>Afterwards, you can find your virtual machine under <strong>Settings > Resources</strong>.
+            externalRef="https://github.com/redhat-developer/podman-desktop-rhel-ext">Macadam extension</Link>.<br/>Afterwards, you can find your virtual machine under <Link action={bootcClient.openResources}>Settings &gt; Resources</Link>.
         </p>
         <Button
           class="py-3"

--- a/packages/frontend/src/lib/Link.svelte
+++ b/packages/frontend/src/lib/Link.svelte
@@ -9,9 +9,10 @@ interface Props {
   internalRef?: string;
   externalRef?: string;
   folder?: string;
+  action?: () => void;
   children?: Snippet;
 }
-let { title, internalRef, externalRef, folder, children }: Props = $props();
+let { title, internalRef, externalRef, folder, action, children }: Props = $props();
 
 async function click(): Promise<void> {
   if (internalRef) {
@@ -20,6 +21,8 @@ async function click(): Promise<void> {
     await bootcClient.openLink(externalRef);
   } else if (folder) {
     await bootcClient.openFolder(folder);
+  } else if (action) {
+    action();
   }
 }
 </script>

--- a/packages/shared/src/BootcAPI.ts
+++ b/packages/shared/src/BootcAPI.ts
@@ -47,6 +47,7 @@ export abstract class BootcApi {
   abstract openFolder(folder: string): Promise<boolean>;
   abstract generateUniqueBuildID(name: string): Promise<string>;
   abstract openLink(link: string): Promise<void>;
+  abstract openResources(): Promise<void>;
   abstract isLinux(): Promise<boolean>;
   abstract isMac(): Promise<boolean>;
   abstract isWindows(): Promise<boolean>;


### PR DESCRIPTION
### What does this PR do?

Turns the text Settings > Resources into a link to the correct page. Requires support for triggering an action from the Link component, and routing to the backend in order to trigger the Podman Desktop navigation API.

### Screenshot / video of UI

<img width="492" alt="Screenshot 2025-05-07 at 1 13 13 PM" src="https://github.com/user-attachments/assets/158edc68-d69a-4f79-868a-395724f2c769" />

### What issues does this PR fix or reference?

Part of #1588.

### How to test this PR?

Create a VM and just check that Settings > Resources is now a working link.