### PR TITLE
feat: enables virtual machine creation for linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,26 @@ podman machine ssh
 rpm-ostree override reset --all
 ```
 
+**(Linux only) Unable to create virtual machine:**
+
+When creating a virtual machine on Linux, you may encounter a "macadam binary is missing" or "gvproxy binary is missing" message. This is because the binaries required have to be installed manually.
+
+Follow the below steps for the solution:
+
+**macadam binary:**
+
+1. Download the [macadam binary](https://github.com/crc-org/macadam/releases)
+2. `chmod +x macadam-linux-amd64`
+3. `sudo mkdir -p /opt/macadam/bin`
+4. `sudo mv macadam-linux-amd64 /opt/macadam/bin/macadam`
+
+**gvproxy binary:**
+
+1. Download the [gvproxy binary](https://github.com/containers/gvisor-tap-vsock/releases)
+2. `chmod +x gvproxy-linux-amd64`
+3. `sudo mkdir /usr/libexec/podman`
+4. `sudo mv gvproxy-linux-amd64 /usr/libexec/podman/gvproxy`
+
 ## Contributing
 
 Want to help develop and contribute to the bootc extension? View our [CONTRIBUTING](https://github.com/containers/podman-desktop-extension-bootc/blob/main/CONTRIBUTING.md) document.

--- a/packages/frontend/src/lib/disk-image/DiskImageActions.spec.ts
+++ b/packages/frontend/src/lib/disk-image/DiskImageActions.spec.ts
@@ -84,3 +84,23 @@ test('Test clicking on logs button', async () => {
 
   expect(window.location.href).toContain('/build');
 });
+
+test('Render the Create VM button if NOT on Windows', async () => {
+  vi.mocked(bootcClient.isWindows).mockResolvedValue(false);
+  render(DiskImageActions, { object: mockHistoryInfo });
+
+  await vi.waitFor(() => {
+    const createVmButton = screen.getByRole('button', { name: 'Create VM' });
+    expect(createVmButton).not.toBeNull();
+  });
+});
+
+test('Do not render the Create VM button if on Windows', async () => {
+  vi.mocked(bootcClient.isWindows).mockResolvedValue(true);
+  render(DiskImageActions, { object: mockHistoryInfo });
+
+  await vi.waitFor(() => {
+    const createVmButton = screen.queryByRole('button', { name: 'Create VM' });
+    expect(createVmButton).toBeNull();
+  });
+});

--- a/packages/frontend/src/lib/disk-image/DiskImageActions.svelte
+++ b/packages/frontend/src/lib/disk-image/DiskImageActions.svelte
@@ -14,7 +14,7 @@ interface Props {
 
 let { object, detailed = false }: Props = $props();
 let isLinux = $state(false);
-let isMac = $state(false);
+let isWindows = $state(false);
 
 // Delete the build
 async function deleteBuild(): Promise<void> {
@@ -38,15 +38,13 @@ async function initMacadamVM(): Promise<void> {
 
 onMount(async () => {
   isLinux = await bootcClient.isLinux();
-  isMac = await bootcClient.isMac();
+  isWindows = await bootcClient.isWindows();
 });
 </script>
 
 {#if !detailed}
   <!-- Only show if Linux, as Macadam Linux isn't supported yet: -->
-  {#if object.arch && isLinux}
-    <ListItemButtonIcon title="Launch VM" onClick={gotoVM} detailed={detailed} icon={faTerminal} />
-  {:else if object.arch && isMac}
+  {#if object.arch && !isWindows}
     <ListItemButtonIcon title="Create VM" onClick={initMacadamVM} detailed={detailed} icon={faTerminal} />
   {/if}
   <ListItemButtonIcon title="Build Logs" onClick={gotoLogs} detailed={detailed} icon={faFileAlt} />


### PR DESCRIPTION
feat: enables virtual machine creation for linux

### What does this PR do?

* Modifies the if statement so that it shows for both mac and linux and
  not Windows
* Updates the macadam.js package to the most up-to-date / latest one.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

![Screenshot from 2025-05-08 13-45-37](https://github.com/user-attachments/assets/3a913405-9490-4b14-8415-45d352b1037d)



### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/podman-desktop/extension-bootc/issues/1587

### How to test this PR?

Must test this out in the OCI image mode / don't use `pnpm watch`,
although `pnpm watch` will work, it's better to test this out in a
"production" environment.

1. Follow the README to install the required binaries
2. `pnpm build`
3. BUILD the image with `podman build`
4. Push the image somewhere
5. Install the OCI image under extensions.
6. Test out creating / starting / access the terminal on the VM.

<!-- Please explain steps to reproduce -->

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
