### PR TITLE
fix: use fake timers to avoid timing issue in disk image test

### DIFF
--- a/packages/frontend/src/lib/disk-image/DiskImageDetailsBuild.spec.ts
+++ b/packages/frontend/src/lib/disk-image/DiskImageDetailsBuild.spec.ts
@@ -16,7 +16,7 @@
  ***********************************************************************/
 
 import { render, screen, waitFor } from '@testing-library/svelte';
-import { vi, test, expect, beforeAll, beforeEach } from 'vitest';
+import { vi, test, expect, beforeAll, beforeEach, afterAll } from 'vitest';
 import DiskImageDetailsBuild from './DiskImageDetailsBuild.svelte';
 import { bootcClient } from '/@/api/client';
 import type { Subscriber } from '/@shared/src/messages/MessageProxy';
@@ -48,10 +48,15 @@ beforeAll(() => {
       };
     },
   });
+  vi.useFakeTimers();
 });
 
 beforeEach(() => {
   vi.clearAllMocks();
+});
+
+afterAll(() => {
+  vi.useRealTimers();
 });
 
 const mockLogs = `Build log line 1
@@ -93,13 +98,6 @@ test('Refreshes logs correctly', async () => {
   render(DiskImageDetailsBuild, { folder: '/empty/logs' });
 
   // verify we start refreshing logs
-  await vi.waitFor(
-    () => {
-      expect(bootcClient.loadLogsFromFolder).toHaveBeenCalledTimes(2);
-    },
-    {
-      timeout: 3_500,
-      interval: 250,
-    },
-  );
+  await vi.advanceTimersByTimeAsync(2500);
+  expect(bootcClient.loadLogsFromFolder).toHaveBeenCalledTimes(2);
 });


### PR DESCRIPTION
### What does this PR do?

Just switches to fake timers so that we can advance exactly one step instead of being dependent on timing between the component and waitFor() test.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes #1624.

### How to test this PR?

Confirm PR checks pass.