### PR TITLE
fix: wait for onmount and use fixed timer advance

### DIFF
--- a/packages/frontend/src/lib/disk-image/DiskImageDetailsBuild.spec.ts
+++ b/packages/frontend/src/lib/disk-image/DiskImageDetailsBuild.spec.ts
@@ -94,10 +94,17 @@ test('Handles empty logs correctly', async () => {
 test('Refreshes logs correctly', async () => {
   vi.mocked(bootcClient.loadLogsFromFolder).mockResolvedValue(mockLogs);
   vi.mocked(bootcClient.getConfigurationValue).mockResolvedValue(14);
+  vi.spyOn(global, 'setInterval');
 
   render(DiskImageDetailsBuild, { folder: '/empty/logs' });
 
+  // make sure the timer is created (onMount has run)
+  await waitFor(() => {
+    expect(setInterval).toHaveBeenCalled();
+  });
+
   // verify we start refreshing logs
-  await vi.advanceTimersByTimeAsync(2500);
+  expect(bootcClient.loadLogsFromFolder).toHaveBeenCalledTimes(1);
+  vi.advanceTimersToNextTimer();
   expect(bootcClient.loadLogsFromFolder).toHaveBeenCalledTimes(2);
 });

--- a/packages/frontend/src/lib/disk-image/DiskImageDetailsBuild.spec.ts
+++ b/packages/frontend/src/lib/disk-image/DiskImageDetailsBuild.spec.ts
@@ -94,13 +94,13 @@ test('Handles empty logs correctly', async () => {
 test('Refreshes logs correctly', async () => {
   vi.mocked(bootcClient.loadLogsFromFolder).mockResolvedValue(mockLogs);
   vi.mocked(bootcClient.getConfigurationValue).mockResolvedValue(14);
-  vi.spyOn(global, 'setInterval');
+  const setIntervalSpy = vi.spyOn(global, 'setInterval');
 
   render(DiskImageDetailsBuild, { folder: '/empty/logs' });
 
   // make sure the timer is created (onMount has run)
   await waitFor(() => {
-    expect(setInterval).toHaveBeenCalled();
+    expect(setIntervalSpy).toHaveBeenCalled();
   });
 
   // verify we start refreshing logs


### PR DESCRIPTION
### What does this PR do?

The previous change switched to a fixed timer which is much more predictable and worked on main, but still fails on most builds. The failure is at least repeatable now, and shows the next problem: onMount is async, so there's no guarantee that the initial fetch or call to setInterval() has happened when we advance the timer and do the test.

This spys on setInterval to confirm that onMount() has executed and the initial fetch was done, then advances the timer once to make sure we've done exactly one step. Being called twice appears to be vitest artifact; does not happen when testing.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes #1624.

### How to test this PR?

PR checks pass.