### PR TITLE
fix(DiskImageDetailsBuild.spec): test isolation through fake timers

### DIFF
--- a/packages/frontend/src/lib/disk-image/DiskImageDetailsBuild.spec.ts
+++ b/packages/frontend/src/lib/disk-image/DiskImageDetailsBuild.spec.ts
@@ -16,7 +16,7 @@
  ***********************************************************************/
 
 import { render, screen, waitFor } from '@testing-library/svelte';
-import { vi, test, expect, beforeAll, beforeEach, afterAll } from 'vitest';
+import { vi, test, expect, beforeAll, beforeEach, afterEach } from 'vitest';
 import DiskImageDetailsBuild from './DiskImageDetailsBuild.svelte';
 import { bootcClient } from '/@/api/client';
 import type { Subscriber } from '/@shared/src/messages/MessageProxy';
@@ -37,25 +37,29 @@ vi.mock('/@/api/client', async () => ({
 
 beforeAll(() => {
   Object.defineProperty(window, 'ResizeObserver', {
-    value: vi.fn().mockReturnValue({ observe: vi.fn(), unobserve: vi.fn() }),
+    value: vi.fn(),
   });
   Object.defineProperty(window, 'matchMedia', {
-    value: () => {
-      return {
-        matches: false,
-        addListener: (): void => {},
-        removeListener: (): void => {},
-      };
-    },
+    value: vi.fn(),
   });
-  vi.useFakeTimers();
 });
 
 beforeEach(() => {
-  vi.clearAllMocks();
+  vi.resetAllMocks();
+  vi.useFakeTimers();
+
+  vi.mocked(window.ResizeObserver).mockReturnValue({
+    observe: vi.fn(),
+    unobserve: vi.fn(),
+  } as unknown as ResizeObserver);
+  vi.mocked(window.matchMedia).mockReturnValue({
+    matches: false,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+  } as unknown as MediaQueryList);
 });
 
-afterAll(() => {
+afterEach(() => {
   vi.useRealTimers();
 });
 


### PR DESCRIPTION
### What does this PR do?

Running the test `Refreshes logs correctly` alone works on my machine, running the test file make the test fails, I believe this may be some kind of test isolation problem.

1. Set window mock in the beforeAll
2. Mock return value in the beforeEach
3. Replace `vi.clearAllMock` with `vi.resetAllMock`
4. Init & Reset the fake timers before and after each test

### How to test this PR?

- Pipeline should be 🟢 
