### PR TITLE
chore: add ssh2 to Containerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,7 @@
 node_modules
 !node_modules/@crc-org/macadam.js
+!node_modules/ssh2
+!node_modules/asn1
+!node_modules/bcrypt-pbkdf
+!node_modules/safer-buffer
+!node_modules/tweetnacl

--- a/Containerfile
+++ b/Containerfile
@@ -24,10 +24,17 @@ COPY packages/backend/icon.png /extension/
 COPY packages/backend/bootable.woff2 /extension/
 COPY README.md /extension/
 
+# TEMPORARY. Permanent fix will be in the future when we can add all of this to vite script.
 # We require the macadam.js binaries and library, so we will manually copy this over to the container image.
 # we rely on `pnpm build` before creating the container image, so we can safely assume that the macadam.js binaries are already present in the node_modules directory
 # and can copy them over to the container image.
 COPY node_modules/@crc-org/macadam.js /extension/node_modules/@crc-org/macadam.js
+# Copy over ssh2 and it's dependencies (run jq '.dependencies' node_modules/ssh2/package.json locally to see)
+COPY node_modules/ssh2 /extension/node_modules/ssh2
+COPY node_modules/asn1 /extension/node_modules/asn1
+COPY node_modules/bcrypt-pbkdf /extension/node_modules/bcrypt-pbkdf
+COPY node_modules/safer-buffer /extension/node_modules/safer-buffer
+COPY node_modules/tweetnacl /extension/node_modules/tweetnacl
 
 FROM scratch
 


### PR DESCRIPTION
chore: add ssh2 to Containerfile

### What does this PR do?

Temporary fix in order to get the next release out. We should work
post-release on vite / plugin script for this.

Adds ssh2 (and it's other dependencies) to node_modules.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

N/A

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Part of https://github.com/podman-desktop/extension-bootc/issues/1633

### How to test this PR?

<!-- Please explain steps to reproduce -->

1. `pnpm build`
2. Build the container image
3. Install VIA CONTAINER IMAGE within podman desktop
4. Test that terminal functionality works fine under Resources >
   Settings.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
