### PR TITLE
chore: remove virtual machine experimental tab

### DIFF
--- a/packages/frontend/src/lib/disk-image/DiskImageDetails.svelte
+++ b/packages/frontend/src/lib/disk-image/DiskImageDetails.svelte
@@ -12,7 +12,6 @@ import { historyInfo } from '/@/stores/historyInfo';
 import { goToDiskImages } from '../navigation';
 import DiskImageDetailsVirtualMachine from './DiskImageDetailsVirtualMachine.svelte';
 import type { Unsubscriber } from 'svelte/store';
-import { bootcClient } from '/@/api/client';
 import DiskImageActions from './DiskImageActions.svelte';
 
 interface Props {
@@ -23,13 +22,8 @@ let { id }: Props = $props();
 let diskImage = $state<BootcBuildInfo>();
 let detailsPage = $state<DetailsPage>();
 let historyInfoUnsubscribe = $state<Unsubscriber>();
-let isMac = $state(false);
-let isLinux = $state(false);
 
 onMount(async () => {
-  isMac = await bootcClient.isMac();
-  isLinux = await bootcClient.isLinux();
-
   // Subscribe to the history to update the details page
   const actualId = atob(id);
   historyInfoUnsubscribe = historyInfo.subscribe(value => {
@@ -71,13 +65,6 @@ onDestroy(() => {
   <svelte:fragment slot="tabs">
     <Tab title="Summary" selected={isTabSelected($router.path, 'summary')} url={getTabUrl($router.path, 'summary')} />
     <Tab title="Build Log" selected={isTabSelected($router.path, 'build')} url={getTabUrl($router.path, 'build')} />
-    <!-- Our "experimental" support is only supported on Linux now, as we have the Macadam button for macOS. -->
-    {#if isLinux}
-      <Tab
-        title="Virtual Machine (Experimental)"
-        selected={isTabSelected($router.path, 'vm')}
-        url={getTabUrl($router.path, 'vm')} />
-    {/if}
   </svelte:fragment>
   <svelte:fragment slot="content">
     <Route path="/summary" breadcrumb="Summary">


### PR DESCRIPTION
chore: remove virtual machine experimental tab

### What does this PR do?

Removes the tab since we no longer use it, we use macadam instead now.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

N/A

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

N/A

### How to test this PR?

1. Install extension
2. No longer see VM tab for Linux

<!-- Please explain steps to reproduce -->

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
