### PR TITLE
chore: switch macadam versions, catch init failure

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -126,7 +126,7 @@
     "vitest": "^3.1.2"
   },
   "dependencies": {
-    "@crc-org/macadam.js": "0.0.1-202505091153-d597ec3",
+    "@crc-org/macadam.js": "0.0.1-202505091308-41f281b",
     "semver": "^7.7.2",
     "compare-versions": "^6.1.1",
     "ssh2": "^1.16.0"

--- a/packages/backend/src/extension.ts
+++ b/packages/backend/src/extension.ts
@@ -176,7 +176,11 @@ export async function activate(extensionContext: ExtensionContext): Promise<void
   );
 
   macadam = new macadamJSPackage.Macadam(macadamName);
-  await macadam.init();
+  try {
+    await macadam.init();
+  } catch (error) {
+    console.error('Error initializing macadam', error);
+  }
 
   const provider = await createProvider(extensionContext);
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,8 +117,8 @@ importers:
   packages/backend:
     dependencies:
       '@crc-org/macadam.js':
-        specifier: 0.0.1-202505091153-d597ec3
-        version: 0.0.1-202505091153-d597ec3
+        specifier: 0.0.1-202505091308-41f281b
+        version: 0.0.1-202505091308-41f281b
       compare-versions:
         specifier: ^6.1.1
         version: 6.1.1
@@ -563,6 +563,9 @@ packages:
 
   '@crc-org/macadam.js@0.0.1-202505091153-d597ec3':
     resolution: {integrity: sha512-W1u4SR1kmacwAXEo2nlahQgN9NEDUjmoaWCmJ44RNsxHVubDrQ/Cl6Ws+W4fJtIM5UsRlNFY4CwrRzeXS0WkVA==}
+
+  '@crc-org/macadam.js@0.0.1-202505091308-41f281b':
+    resolution: {integrity: sha512-h3SipcK5ebuq+xwNs77jidW926mSOJYPvBevPO4+tj1gi9iAlEYuw42etNi8pUBxcaWk/l7yeJcbNC0wCYvSQw==}
 
   '@csstools/color-helpers@5.0.2':
     resolution: {integrity: sha512-JqWH1vsgdGcw2RR6VliXXdA0/59LttzlU8UlRT/iUUsEeWfYq8I+K0yhihEUTTHLRm1EXvpsCx3083EU15ecsA==}
@@ -4453,6 +4456,10 @@ snapshots:
       chalk: 5.4.1
 
   '@crc-org/macadam.js@0.0.1-202505091153-d597ec3':
+    dependencies:
+      '@podman-desktop/api': 1.18.1
+
+  '@crc-org/macadam.js@0.0.1-202505091308-41f281b':
     dependencies:
       '@podman-desktop/api': 1.18.1
 


### PR DESCRIPTION
### What does this PR do?

Switching to correct macadam version with binaries, and adding try/catch around the init to avoid extension failure and have better logging if init fails.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes #1637.

### How to test this PR?

Install on fresh machine and confirm macadam gets installed correctly / extension starts correctly.