### PR TITLE
fix: prefill correct path for qcow2 images

### DIFF
--- a/packages/frontend/src/lib/disk-image/DiskImageActions.svelte
+++ b/packages/frontend/src/lib/disk-image/DiskImageActions.svelte
@@ -31,8 +31,12 @@ async function gotoVM(): Promise<void> {
 }
 
 async function initMacadamVM(): Promise<void> {
-  // We must pass in the full path to the disk image, so we combine object.folder as well as 'image/disk.raw'.
-  const imagePath = object.folder + '/image/disk.raw';
+  let imagePath = object.folder;
+  if (object.type.includes('raw')) {
+    imagePath += '/image/disk.raw';
+  } else if (object.type.includes('qcow2')) {
+    imagePath += '/qcow2/disk.qcow2';
+  }
   await gotoCreateVM(object.image, imagePath);
 }
 


### PR DESCRIPTION
### What does this PR do?

Only raw and qcow2 images are supported for now. This adds the correct path for qcow2 and doesn't assume the raw path for other types - user will see the error when they go to the page.

Had to update the invalid logs button test first, then added two tests for clicking on the create VM button for raw and qcow2. Just checking the final (btoa encoded) output for now.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes #1650.

### How to test this PR?

Click on the button to create a VM from both a raw and qcow2 disk image and confirm the paths are correct.