### PR TITLE
chore: update minimum pd version

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -41,6 +41,6 @@ FROM scratch
 LABEL org.opencontainers.image.title="Bootable Container Extension" \
         org.opencontainers.image.description="Podman Desktop extension for bootable OS containers (bootc) and generating disk images" \
         org.opencontainers.image.vendor="Red Hat" \
-        io.podman-desktop.api.version=">= 1.10.0"
+        io.podman-desktop.api.version=">= 1.18.0"
 
 COPY --from=builder /extension /extension

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -7,7 +7,7 @@
   "publisher": "redhat",
   "license": "Apache-2.0",
   "engines": {
-    "podman-desktop": ">=1.10.0"
+    "podman-desktop": ">=1.18.0"
   },
   "main": "./dist/extension.js",
   "contributes": {


### PR DESCRIPTION
### What does this PR do?

The catalog will enforce this separately, but we now depend on VM support in Podman Desktop, which was added in the 1.18 release.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

N/A

### How to test this PR?

Try to install on current and older version, Podman Desktop should block from older version only.