### PR TITLE
chore: add disclaimer that to test VM, have to add ssh key

### DIFF
--- a/packages/frontend/src/Build.svelte
+++ b/packages/frontend/src/Build.svelte
@@ -60,6 +60,7 @@ let errorFormValidation: string | undefined = undefined;
 // this boolean will be set to true if the selected image is Fedora and shown as a warning to the user.
 let fedoraDetected = false;
 let isLinux: boolean;
+let isMac: boolean;
 
 // AWS Related
 let awsAmiName: string = '';
@@ -420,6 +421,7 @@ function removeEmptyStrings<T>(obj: T): T | undefined {
 
 onMount(async () => {
   isLinux = await bootcClient.isLinux();
+  isMac = await bootcClient.isMac();
   const images = await bootcClient.listBootcImages();
 
   // filter to images that have a repo tag here, to avoid doing it everywhere
@@ -1085,14 +1087,24 @@ $: if (availableArchitectures) {
         {#if buildInProgress}
           <Button class="w-full" disabled={true}>Creating build task</Button>
         {:else}
-          <Button on:click={buildBootcImage} disabled={errorFormValidation !== undefined} class="w-full">Build</Button>
+
+          <!-- macOS and Linux you can use Macadam / VM creation, show a disclaimer as a tip that you should add your public SSH key to test the VM. -->
+          <!-- On macOS and Linux, show tip about SSH key for VM testing -->
+          {#if isMac || isLinux}
+            <p class="text-sm text-[var(--pd-content-text)] m-0 pt-0" data-testid="vm-disclaimer">
+              To test the virtual machine, add your public SSH key under <b>Users</b> in the interactive build config. Set the output format to RAW or QCOW2.
+            </p>
+          {/if}
+
           <!-- If on Linux, warn that during the build, credentials will be asked in order to run an escalated privileged build prompt -->
           {#if isLinux}
-            <p class="text-sm text-[var(--pd-content-text)] pt-1">
+            <p class="text-sm text-[var(--pd-content-text)] m-0 pt-0">
               For Linux users during the build, you will be asked for your credentials in order to run an escalated
               privileged build prompt for the build process.
             </p>
           {/if}
+
+          <Button on:click={buildBootcImage} disabled={errorFormValidation !== undefined} class="w-full mt-1">Build</Button>
         {/if}
       </div>
     {/if}


### PR DESCRIPTION
chore: add disclaimer that to test, have to add ssh key

### What does this PR do?

* Adds a small disclaimer that only appears on mac or linux that you
  should add your SSH key + do output as raw or qcow2
* For this PR, I also did an alternative way of doing tests since I did
  not want to copy / paste and only be changing one thing. So in this PR
  the tests are "table-based".

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

![Screenshot 2025-05-28 at 11 41 35 AM](https://github.com/user-attachments/assets/d5d091fb-e109-41aa-a625-918915e30ba8)



### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/podman-desktop/extension-bootc/issues/1569

### How to test this PR?

<!-- Please explain steps to reproduce -->

1. pnpm watch
2. See that the disclaimer is shwon on the build page.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
