### PR TITLE
chore: update RHEL bib image to 9.6

### DIFF
--- a/packages/backend/src/constants.ts
+++ b/packages/backend/src/constants.ts
@@ -20,5 +20,5 @@
 export const bootcImageBuilder = 'bootc-image-builder';
 export const bootcImageBuilderCentos =
   'quay.io/centos-bootc/bootc-image-builder:sha256-de948b4d66006b26e2cb6a051afdb3cfcd569c9db52bb6fe7b1f2236ad216207';
-export const bootcImageBuilderRHEL = 'registry.redhat.io/rhel9/bootc-image-builder:9.5';
+export const bootcImageBuilderRHEL = 'registry.redhat.io/rhel9/bootc-image-builder:9.6';
 export const macadamName = 'bootc';


### PR DESCRIPTION
chore: update RHEL bib image to 9.6

### What does this PR do?

Update the bib image for RHEL to 9.6.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

N/A

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/podman-desktop/extension-bootc/issues/1726

### How to test this PR?

1. Switch to RHEL image builder (within settings)
2. Build the example (httpd)
3. See it's successfully built.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
