### PR TITLE
chore: rename Disk Images to disk images for search

### DIFF
--- a/packages/frontend/src/lib/disk-image/DiskImagesList.spec.ts
+++ b/packages/frontend/src/lib/disk-image/DiskImagesList.spec.ts
@@ -83,7 +83,7 @@ test('Homepage renders correctly with multiple rows', async () => {
 
   render(DiskImagesList);
   await vi.waitFor(() => {
-    if (!screen.queryByText('Disk Images')) {
+    if (!screen.queryByText('disk images')) {
       throw new Error();
     }
   });
@@ -103,7 +103,7 @@ test('Test clicking on delete button', async () => {
 
   render(DiskImagesList);
   await vi.waitFor(() => {
-    if (!screen.queryByText('Disk Images')) {
+    if (!screen.queryByText('disk images')) {
       throw new Error();
     }
   });
@@ -122,7 +122,7 @@ test('Test clicking on build button', async () => {
 
   render(DiskImagesList);
   await vi.waitFor(() => {
-    if (!screen.queryByText('Disk Images')) {
+    if (!screen.queryByText('disk images')) {
       throw new Error();
     }
   });
@@ -140,7 +140,7 @@ test('On non-windows, the Create VM button should show', async () => {
 
   render(DiskImagesList);
   await vi.waitFor(() => {
-    if (!screen.queryByText('Disk Images')) {
+    if (!screen.queryByText('disk images')) {
       throw new Error();
     }
   });
@@ -155,7 +155,7 @@ test('On windows, the Create VM button should not show', async () => {
 
   render(DiskImagesList);
   await vi.waitFor(() => {
-    if (!screen.queryByText('Disk Images')) {
+    if (!screen.queryByText('disk images')) {
       throw new Error();
     }
   });

--- a/packages/frontend/src/lib/disk-image/DiskImagesList.svelte
+++ b/packages/frontend/src/lib/disk-image/DiskImagesList.svelte
@@ -124,7 +124,7 @@ const row = new TableRow<BootcBuildInfo>({
 });
 </script>
 
-<NavPage bind:searchTerm={searchTerm} title="Disk Images" searchEnabled={true}>
+<NavPage bind:searchTerm={searchTerm} title="disk images" searchEnabled={true}>
   <svelte:fragment slot="additional-actions">
   <!-- Only show for macOS and Linux -->
   {#if !isWindows}


### PR DESCRIPTION
chore: rename Disk Images to disk images for search

### What does this PR do?

Changes the capitalization to fit conventional other sections of Podman
Desktop

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

![Screenshot 2025-06-26 at 12 15 00 PM](https://github.com/user-attachments/assets/72a09475-5b1c-4653-b178-a6be5985568b)


### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/podman-desktop/extension-bootc/issues/1528

### How to test this PR?

See change in UI that it is now "Search disk images"

<!-- Please explain steps to reproduce -->

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
