### PR TITLE
chore: fix e2e, switch to 24.04 ubuntu

### DIFF
--- a/.github/workflows/e2e-main.yaml
+++ b/.github/workflows/e2e-main.yaml
@@ -76,7 +76,7 @@ jobs:
       - name: Update podman
         run: |
           # ubuntu version from kubic repository to install podman we need (v5)
-          ubuntu_version='23.04'
+          ubuntu_version='24.04'
           sudo sh -c "echo 'deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_${ubuntu_version}/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:unstable.list"
           curl -L "https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_${ubuntu_version}/Release.key" | sudo apt-key add -
           # install necessary dependencies for criu package which is not part of 23.04


### PR DESCRIPTION
chore: fix e2e out of sync mirror

### What does this PR do?

e2e keeps flaking.

It's because we use 24.04 as a base image, but specific 23.04 in the apt-get / podman install.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

N/A

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

N/A

### How to test this PR?

<!-- Please explain steps to reproduce -->

N/A

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
