### PR TITLE
chore: update bib to remove missing platform id issue

### DIFF
--- a/packages/backend/src/constants.ts
+++ b/packages/backend/src/constants.ts
@@ -19,6 +19,6 @@
 // Image related
 export const bootcImageBuilder = 'bootc-image-builder';
 export const bootcImageBuilderCentos =
-  'quay.io/centos-bootc/bootc-image-builder:sha256-de948b4d66006b26e2cb6a051afdb3cfcd569c9db52bb6fe7b1f2236ad216207';
+  'quay.io/centos-bootc/bootc-image-builder:sha256-106ae79c812993d6dd626d5f41c6104d711d7d86319918d6235538219d639adc';
 export const bootcImageBuilderRHEL = 'registry.redhat.io/rhel9/bootc-image-builder:9.6';
 export const macadamName = 'bootc';


### PR DESCRIPTION
chore: update bib to remove missing platform id issue

### What does this PR do?

Updates BIB to remove an issue with missing PLATFORM_ID with Fedora
43.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/podman-desktop/extension-bootc/issues/1806

### How to test this PR?

<!-- Please explain steps to reproduce -->

Use this bootc extension with bib and see everything builds correctly,
etc.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
