### PR TITLE
refactor: use repository from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "bootc",
   "displayName": "Bootable Container",
   "description": "Support for bootable OS containers (bootc) and generating disk images",
+  "repository": "https://github.com/podman-desktop/extension-bootc",
   "version": "1.10.0-next",
   "icon": "icon.png",
   "publisher": "redhat",

--- a/packages/frontend/src/Build.spec.ts
+++ b/packages/frontend/src/Build.spec.ts
@@ -28,6 +28,7 @@ import { router } from 'tinro';
 import userEvent from '@testing-library/user-event';
 import { historyInfo } from './stores/historyInfo';
 import type { Subscriber } from '/@shared/src/messages/MessageProxy';
+import { REPOSITORY_URL } from '/@shared/src/repository-infos';
 
 const mockHistoryInfo: BootcBuildInfo[] = [
   {
@@ -454,7 +455,7 @@ test('Do not show an image if it has no repotags and has isManifest as false', a
 
   await userEvent.click(link);
 
-  expect(bootcClient.openLink).toBeCalledWith('https://github.com/containers/podman-desktop-extension-bootc');
+  expect(bootcClient.openLink).toBeCalledWith(REPOSITORY_URL);
 });
 
 test('If inspectImage fails, do not select any architecture / make them available', async () => {

--- a/packages/frontend/src/Build.svelte
+++ b/packages/frontend/src/Build.svelte
@@ -23,11 +23,10 @@ import { Button, Input, EmptyScreen, FormPage, Checkbox, ErrorMessage, Expandabl
 import Link from './lib/Link.svelte';
 import { historyInfo } from '/@/stores/historyInfo';
 import { goToDiskImages } from './lib/navigation';
+import { REPOSITORY_URL } from '/@shared/src/repository-infos';
 
 export let imageName: string | undefined = undefined;
 export let imageTag: string | undefined = undefined;
-
-const bootcExtensionGithubUrl = 'https://github.com/podman-desktop/extension-bootc';
 
 // Image variables
 let selectedImage: string | undefined;
@@ -623,7 +622,7 @@ $: if (availableArchitectures) {
             {#if bootcAvailableImages.length === 0}
               <p class="text-[var(--pd-state-warning)] pt-1">
                 No bootable container compatible images found. Learn to create one on our <Link
-                  externalRef="https://github.com/containers/podman-desktop-extension-bootc">README</Link
+                  externalRef={REPOSITORY_URL}>README</Link
                 >.
               </p>
             {/if}
@@ -819,7 +818,7 @@ $: if (availableArchitectures) {
                 <p class="text-sm text-[var(--pd-state-warning)] pt-2"
                 data-testid="cross-architecture-warning">
                   Cross-architecture building may not work correctly on macOS. Please refer to our
-                  <Link externalRef={bootcExtensionGithubUrl}>README</Link> for more information.
+                  <Link externalRef={REPOSITORY_URL}>README</Link> for more information.
                 </p>
               {/if}
               <p class="text-sm text-[var(--pd-content-text)] pt-2">

--- a/packages/frontend/src/lib/dashboard/Dashboard.svelte
+++ b/packages/frontend/src/lib/dashboard/Dashboard.svelte
@@ -13,6 +13,7 @@ import redhatImage from './redhat.png';
 import fedoraImage from './fedora.png';
 import BootcImageIcon from '../BootcImageIcon.svelte';
 import FirstImage from '../FirstImage.svelte';
+import { REPOSITORY_URL } from '/@shared/src/repository-infos';
 
 let bootcImageCount = $derived($imageInfo.length);
 let diskImageCount = $derived($historyInfo.length);
@@ -20,7 +21,6 @@ let diskImageCount = $derived($historyInfo.length);
 const bootcImageBuilderSite = 'https://github.com/osbuild/bootc-image-builder';
 const bootcSite = 'https://bootc-dev.github.io/bootc/';
 const fedoraBaseImages = 'https://docs.fedoraproject.org/en-US/bootc/base-images/';
-const extensionSite = 'https://github.com/containers/podman-desktop-extension-bootc';
 </script>
 
 <DashboardPage>
@@ -39,7 +39,7 @@ const extensionSite = 'https://github.com/containers/podman-desktop-extension-bo
           >, and <Link externalRef={bootcSite}>bootc</Link>, your container image is transformed into a bootable disk image.
         </div>
         <div>
-          Want to learn more including building your own Containerfile? Check out the <Link externalRef={extensionSite}
+          Want to learn more including building your own Containerfile? Check out the <Link externalRef={REPOSITORY_URL}
             >extension documentation</Link>.
         </div>
       </div>

--- a/packages/frontend/src/lib/disk-image/DiskImageDetailsVirtualMachine.svelte
+++ b/packages/frontend/src/lib/disk-image/DiskImageDetailsVirtualMachine.svelte
@@ -13,6 +13,7 @@ import Link from '../Link.svelte';
 import { Messages } from '/@shared/src/messages/Messages';
 import type { Subscriber } from '/@shared/src/messages/MessageProxy';
 import type { BootcBuildInfo } from '/@shared/src/models/bootc';
+import { REPOSITORY_URL } from '/@shared/src/repository-infos';
 
 interface Props {
   build: BootcBuildInfo | undefined;
@@ -37,7 +38,7 @@ let vmLaunchPrereqs = $state<string>();
 let notifySubscriber = $state<Subscriber>();
 
 const VM_LAUNCH_ERROR_MESSAGE = 'VM launch error';
-const GUIDE_LINK = 'https://github.com/containers/podman-desktop-extension-bootc/blob/main/docs/vm_launcher.md';
+const GUIDE_LINK = `${REPOSITORY_URL}/blob/main/docs/vm_launcher.md`;
 
 // Event handlers for the WebSocket connection
 // which are needed to update the connection status
@@ -305,7 +306,7 @@ export function goToHomePage(): void {
       <p class="text-md">
         View our guide for further information on troubleshooting steps: <Link externalRef={GUIDE_LINK}
           >Virtual Machine Launcher BootC Guide.</Link> If you are still experiencing issues, please open an issue on our
-        <Link externalRef="https://github.com/containers/podman-desktop-extension-bootc">GitHub repository</Link>.
+        <Link externalRef={REPOSITORY_URL}>GitHub repository</Link>.
       </p>
     </div>
   </EmptyScreen>

--- a/packages/shared/src/repository-infos.ts
+++ b/packages/shared/src/repository-infos.ts
@@ -1,0 +1,21 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import rootPackage from '../../../package.json' with { type: 'json' };
+
+export const REPOSITORY_URL = rootPackage.repository;

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -8,7 +8,9 @@
     "skipLibCheck": true,
     "baseUrl": ".",
     "allowJs": true,
-    "checkJs": true
+    "checkJs": true,
+    "resolveJsonModule": true,
+    "allowSyntheticDefaultImports": true
   },
   "include": ["src/**/*.d.ts", "src/**/*.ts", "src/**/*.js", "types/*.d.ts", "../../types/**/*.d.ts"]
 }


### PR DESCRIPTION
### What does this PR do?

This PR introduces the repository field in package.json, and it uses it across the extension Typescript code. It also fixes the outdated repository name found.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Fixes #1836
This is a follow-up of https://github.com/podman-desktop/extension-bootc/pull/1830/files#r2224668335

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to reproduce -->
