### PR TITLE
chore: add commitlint to its group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,7 @@ updates:
       commitlint:
         applies-to: version-updates
         patterns:
+          - 'commitlint'
           - '@commitlint/*'
       eslint:
         applies-to: version-updates


### PR DESCRIPTION
### What does this PR do?

See PRs #1949 and #1950 - commitlint wasn't in the dependabot group with its name. This just moves it in so that the group is correctly batched next time.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

N/A

### How to test this PR?

Wait for next commitlint update...