### PR TITLE
fix(e2e): remove unnecessary workaround for tests-playwright version

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -129,17 +129,9 @@ jobs:
         working-directory: ./podman-desktop
         run: pnpm test:e2e:build
 
-      - name: Ensure getting current HEAD version of the test framework
-        working-directory: ./extension-bootc/tests/playwright
-        run: |
-          # workaround for https://github.com/podman-desktop/extension-bootc/issues/712
-          version=$(npm view @podman-desktop/tests-playwright@next version)
-          echo "Version of @podman-desktop/tests-playwright to be used: $version"
-          jq --arg version "$version" '.devDependencies."@podman-desktop/tests-playwright" = $version' package.json > package.json_tmp && mv package.json_tmp package.json
-
       - name: Execute pnpm in Bootc Extension
         working-directory: ./extension-bootc
-        run: pnpm install --no-frozen-lockfile
+        run: pnpm install
 
       - name: build extension image
         uses: redhat-actions/buildah-build@v3


### PR DESCRIPTION
-### What does this PR do?

The step was dynamically replacing the `@podman-desktop/tests-playwright` version with the latest `@next` release before running pnpm install. With pnpm v11 minimumReleaseAge defaulting to 1440 minutes, this breaks CI when a @next version was published within the last 24 hours.

The workaround referenced https://github.com/podman-desktop/extension-bootc/issues/712 and is no longer needed.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Required for
- https://github.com/podman-desktop/extension-bootc/pull/2725

### How to test this PR?

CI should be :green_circle: 
