### PR TITLE
fix: resolve CVE-2026-67213 in nanoid

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,8 @@
       "brace-expansion@^5": "5.0.9",
       "shell-quote@>=1.1.0 <1.9.0": ">=1.9.0",
       "js-yaml": ">=4.3.0 <5.0.0",
-      "undici@>=7.23.0 <7.28.0": ">=7.28.0"
+      "undici@>=7.23.0 <7.28.0": ">=7.28.0",
+      "nanoid": ">=3.3.18"
     },
     "ignoredBuiltDependencies": [
       "@biomejs/biome",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,6 +22,7 @@ overrides:
   shell-quote@>=1.1.0 <1.9.0: '>=1.9.0'
   js-yaml: '>=4.3.0 <5.0.0'
   undici@>=7.23.0 <7.28.0: '>=7.28.0'
+  nanoid: '>=3.3.18'
 
 importers:
 
@@ -2914,11 +2915,6 @@ packages:
 
   nan@2.23.0:
     resolution: {integrity: sha512-1UxuyYGdoQHcGg87Lkqm3FzefucTa0NAiOcuRsDmysep3c1LVCRK2krrUDafMWtjSG04htvAmvg96+SDknOmgQ==}
-
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
-    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
-    hasBin: true
 
   nanoid@3.3.18:
     resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
@@ -6418,8 +6414,6 @@ snapshots:
   nan@2.23.0:
     optional: true
 
-  nanoid@3.3.16: {}
-
   nanoid@3.3.18: {}
 
   napi-postinstall@0.3.4: {}
@@ -6574,7 +6568,7 @@ snapshots:
 
   postcss@8.5.20:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 


### PR DESCRIPTION
### What does this PR do?

Fix high severity vulnerability CVE-2026-67213 in `nanoid`.

**Advisory**: nanoid: custom generators can loop indefinitely when size is zero
**Vulnerable versions**: <3.3.18
**Patched versions**: >=3.3.18
**Advisory URL**: https://github.com/advisories/GHSA-2v37-7h3g-55p8

### Screenshot / video of UI

N/A - dependency update only.

### What issues does this PR fix or reference?

Fixes CVE-2026-67213: _nanoid: custom generators can loop indefinitely when size is zero_

### How to test this PR?

Run `pnpm audit` and verify CVE-2026-67213 is no longer reported