### PR TITLE
chore(Containerfile.builder): support pnpm v11

### DIFF
--- a/build/Containerfile.builder
+++ b/build/Containerfile.builder
@@ -31,4 +31,4 @@ COPY --chown=1001:0 packages/frontend/package.json /opt/app-root/extension-sourc
 
 
 RUN corepack enable && corepack install && \
-    CI=true pnpm --frozen-lockfile install
+    CI=true pnpm install

--- a/build/Containerfile.builder
+++ b/build/Containerfile.builder
@@ -17,6 +17,8 @@
 
 FROM registry.access.redhat.com/ubi10/nodejs-24-minimal:10.1-1766060610
 
+RUN npm i -g corepack && corepack enable
+
 # change home directory to be at /opt/app-root
 ENV HOME=/opt/app-root
 
@@ -27,5 +29,6 @@ COPY --chown=1001:0 package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc /opt/
 COPY --chown=1001:0 packages/backend/package.json /opt/app-root/extension-source/packages/backend/package.json
 COPY --chown=1001:0 packages/frontend/package.json /opt/app-root/extension-source/packages/frontend/package.json
 
-RUN npm install --global pnpm@10 && \
-    pnpm --frozen-lockfile install
+
+RUN corepack enable && corepack install && \
+    CI=true pnpm --frozen-lockfile install


### PR DESCRIPTION
### What does this PR do?

The bootc extension is using two Containerfile `Containerfile.builder` and `Containerfile`, the Containerfile.builder **is not** build on pr-check, so we need to update it in a separate PR (Same as https://github.com/podman-desktop/extension-kubernetes-dashboard/pull/1213).

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Required for
- https://github.com/podman-desktop/extension-bootc/pull/2730

### How to test this PR?

```
$: podman build -f build/Containerfile.builder -t ghcr.io/podman-desktop/extension-bootc-builder:next --no-cache .
$: podman build -f build/Containerfile --pull=false  .
```
